### PR TITLE
Fixes issue #49

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -19,7 +19,7 @@
 		return 0
 	return 1
 /datum/spellbook_entry/proc/Buy(mob/living/carbon/human/user,obj/item/weapon/spellbook/book) //return 1 on success
-	if(!S)
+	if(!S|| qdeleted(S))
 		S = new spell_type()
 
 	//Check if we got the spell already


### PR DESCRIPTION
Fixes issue #49, the issue where refunding a spell with efficient or a level higher will allow you to buy it at that same level at the cost of 1.
