### PR TITLE
Timestop sprite no longer blocks objects under it

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -436,6 +436,7 @@
 	pixel_x = -64
 	pixel_y = -64
 	unacidable = 1
+	mouse_opacity = 0
 	var/mob/living/immune = list() // the one who creates the timestop is immune
 	var/freezerange = 2
 	var/duration = 140

--- a/html/changelogs/Xthedark-TimeStopFix.yml
+++ b/html/changelogs/Xthedark-TimeStopFix.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: true
+
+changes: 
+  - bugfix: "Timestop no longer blocks objects under it from being interacted with."


### PR DESCRIPTION
As per title, the Chorno effect no longer blocks objects/people under it from being interacted with. Have fun removing persons clothes, cuffing (but not grabbing). Reverse pickpocketing Clown Wizard that puts honks into pockets can now be a thing.
