### PR TITLE
Transformation Sting fix (Issue #37)

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -365,6 +365,14 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	prof.dna = new_dna
 	prof.name = H.real_name
 	prof.protected = protect
+	prof.gender = H.gender
+	prof.skin_tone = H.skin_tone
+	prof.hair_color = H.hair_color
+	prof.hair_style = H.hair_style
+	prof.facial_hair_color = H.facial_hair_color
+	prof.facial_hair_style = H.facial_hair_style
+	prof.eye_color = H.eye_color
+	prof.features = H.features
 
 	var/list/slots = list("head", "wear_mask", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store")
 	for(var/slot in slots)
@@ -460,6 +468,16 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	var/list/exists_list = list()
 	var/list/item_color_list = list()
 	var/list/item_state_list = list()
+	
+	//Xthedark : Human/Etc appearence data, seems we'll have to save/set this manually
+	var/gender = null
+	var/skin_tone = null
+	var/hair_color = null
+	var/hair_style = null
+	var/facial_hair_color = null
+	var/facial_hair_style = null
+	var/list/features = list()
+	var/eye_color = null
 
 /datum/changelingprofile/Destroy()
 	qdel(dna)

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -65,7 +65,8 @@
 	chemical_cost = 40
 	dna_cost = 3
 	genetic_damage = 100
-	var/datum/dna/selected_dna = null
+	//var/datum/dna/selected_dna = null
+	var/datum/changelingprofile/selected_dna = null
 
 /obj/effect/proc_holder/changeling/sting/transformation/Click()
 	var/mob/user = usr
@@ -87,8 +88,8 @@
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/transformation/sting_action(mob/user, mob/target)
-	add_logs(user, target, "stung", "transformation sting", " new identity is [selected_dna.real_name]")
-	var/datum/dna/NewDNA = selected_dna
+	add_logs(user, target, "stung", "transformation sting", " new identity is [selected_dna.dna.real_name]")
+	var/datum/dna/NewDNA = selected_dna.dna
 	if(ismonkey(target))
 		user << "<span class='notice'>Our genes cry out as we sting [target.name]!</span>"
 
@@ -100,7 +101,21 @@
 	target.visible_message("<span class='danger'>[target] begins to violenty convulse!</span>","<span class='userdanger'>You feel a tiny prick and a begin to uncontrollably convulse!</span>")
 	spawn(10)
 		hardset_dna(target, NewDNA.uni_identity, NewDNA.struc_enzymes, NewDNA.real_name, NewDNA.blood_type, NewDNA.species.type, NewDNA.features)
-		updateappearance(target)
+		if(ishuman(target))
+			var/mob/living/carbon/human/T = target
+			//Setting manually, because updateappearance() doesn't seem to properly make cosmetic changes based on DNA
+			T.gender = selected_dna.gender
+			T.skin_tone = selected_dna.skin_tone
+			T.hair_color = selected_dna.hair_color
+			T.hair_style = selected_dna.hair_style
+			T.facial_hair_color = selected_dna.facial_hair_color
+			T.facial_hair_style = selected_dna.facial_hair_style
+			T.eye_color = selected_dna.eye_color
+			T.features = selected_dna.features
+			T.update_body()
+			T.update_hair()
+		else //Fallback option for non humans
+			updateappearance(target)
 	feedback_add_details("changeling_powers","TS")
 	return 1
 

--- a/html/changelogs/Xthedark-TransformStingFix.yml
+++ b/html/changelogs/Xthedark-TransformStingFix.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: true
+
+changes: 
+  - bugfix: "Syndicate bioengineers have isolated and repaired the genome deficiency that was causing Transformation Sting to not work properly for changeling agents."


### PR DESCRIPTION
Fixes issue #37.
Got Transformation Sting to work but gave up on making monkeys being transformed properly after like 5 hours of trying. It does work with lizardpeople/plantpeople/androids (no mental strength to look up their proper names after all the work).

Problems with this particular solution:
1. Incredibly hacky, since I basically use additional vars in changelingprofile to save and later set appearance data (even though it SHOULD be set after calling hardset_dna, but that doesn't seem to be the case).
2. Monkeys don't get the correct appearance because, basically, any call to updating deletes the old mob and after trying about 3 solutions, I just gave up on making monkeys work (I can only hope updateappearance() accounts for changeling monkeys).
3. Doesn't change the naked sprite (if you were wearing a bra, you will be wearing a bra even if turned into male).

In essence, hardset_dna() just doesn't seem to work properly. The UI is passed, but it doesn't get processed, which causes appearance to not get updated based on DNA and I have to resort to saving/setting this manually.

I'll leave it up to the coders whether or not to merge this. But hey, at least you can turn the captain into a lizardperson and kek for days.
