### PR TITLE
Adds some admin logs and messages to Traitor Panel

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -267,7 +267,6 @@
 			else
 				text += "."
 
-			text += " <a href='?src=\ref[src];revolution=reequip'>Reequip</a> (gives traitor uplink)."
 			if (objectives.len==0)
 				text += "<br>Objectives are empty! <a href='?src=\ref[src];revolution=autoobjectives'>Set to kill all heads</a>."
 		else if(isloyal(current))
@@ -1085,6 +1084,8 @@
 				</b></span>"
 				ticker.mode.finalize_shadowling(src)
 				ticker.mode.update_shadow_icons_added(src)
+				message_admins("[key_name_admin(usr)] has shadowling'ed [current].")
+				log_admin("[key_name(usr)] has shadowling'ed [current].")
 			if("thrall")
 				if(!ishuman(current))
 					usr << "<span class='warning'>This only works on humans!</span>"
@@ -1217,7 +1218,11 @@
 			if("uplink")
 				if (!ticker.mode.equip_traitor(current, !(src in ticker.mode.traitors)))
 					usr << "<span class='danger'>Equipping a syndicate failed!</span>"
-				log_admin("[key_name(usr)] attempted to give [current] an uplink.")
+				if(src in ticker.mode.head_revolutionaries)
+					message_admins("[key_name(usr)] attempted to give [current], a head revolutionary, an uplink.")
+					log_admin("[key_name(usr)] attempted to give [current], a head revolutionary, an uplink.")
+				else
+					log_admin("[key_name(usr)] attempted to give [current] an uplink.")
 
 	else if (href_list["obj_announce"])
 		var/obj_count = 1


### PR DESCRIPTION
Fixes issue #35. It is now logged and admins are alerted when an admin makes a player into a shadowling through the traitor panel.

Fixes issue #62. It is now logged and admins are alerted when an admin gives a head revolutionary an uplink through the traitor panel.

Removed the "Reequip(gives uplink)" button in the revolutionary section of the traitor panel that didn't do anything.

Now with 1/6 the commits.
