### PR TITLE
Syringe fix

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -215,7 +215,7 @@
 
 
 /obj/item/weapon/reagent_containers/syringe/update_icon()
-	var/rounded_vol = min(max(round(reagents.total_volume,5),5),15)
+	var/rounded_vol = Clamp(round(reagents.total_volume,5), 0, 15)
 	overlays.Cut()
 	if(ismob(loc))
 		var/injoverlay

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -12,11 +12,11 @@ Aranclanos = TGCoder
 
 Ephemeralis = HeadCoder
 
-05rhardy = Council
-Xantam = Council
-AsV9 = Council
-Blukey = Council
-Johncena1469 = Council
+05rhardy = Council Member
+Xantam = Council Member
+AsV9 = Council Member
+Blukey = Council Member
+Johncena1469 = Council Member
 
 Joseph Frost = Senior Admin
 Chuggachar = Senior Admin


### PR DESCRIPTION
Fixes syringes being weird due to rounding errors. This means empty syringes actually look empty.
Fixes #94 
