### PR TITLE
Rabid slimes pass rabidity to offspring at a cost of friend list

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -193,7 +193,10 @@
 				if(ckey)	M.nutrition = new_nutrition //Player slimes are more robust at spliting. Once an oversight of poor copypasta, now a feature!
 				M.powerlevel = new_powerlevel
 				if(i != 1) step_away(M,src)
-				M.Friends = Friends.Copy()
+				if(rabid)
+					M.rabid = 1
+				else
+					M.Friends = Friends.Copy()
 				babies += M
 				M.mutation_chance = Clamp(mutation_chance+(rand(5,-5)),0,100)
 				feedback_add_details("slime_babies_born","slimebirth_[replacetext(M.colour," ","_")]")


### PR DESCRIPTION
_Explanation on rabidity : What is a rabid slime? Rabid is a status that a slime can have that makes slime's behavior aggressive (attack on sight), except if you are it's friend or are a slimeperson. To become a friend of a rabid slime, you have to feed it plasma sheet, that's the only way, because rabid slimes don't get friends the "normal" way._

Rabidity is passed to the children, but, if the slime is rabid, it's children will NOT inherit friends, so the only way to make sure you are not glomped is to be a slimeperson, which means you are no longer considered human by AI. There will be no free lunch for Xenobiology this time.

This should make rabid slimes actually dangerous and a legit way for assassination/shuttle hijack/general chaos, without a way to easily abuse this (making rabid slimes a bodyguard without sentience could bite you in the ass - but it's a last resort that you can have available). Also lets player controlled slimes Reproduce option be an actually legit weapon for antags.

Problems:
1. The most immediate problem would be the death of a player controlled slime. You see, when a slime dies, there are 2 mini-slimes created, one of which (the one that isn't controlled by the player) BECOMES RABID. There is a potential for accidental and non-intentional outbreak of rabid slimes when a player-controlled slime is randomly killed by someone.

Good luck! Yay or Nay at your discretion.
