### PR TITLE
Fixed some bot interface buttons being usable when they should not be.

### DIFF
--- a/code/game/machinery/bots/cleanbot.dm
+++ b/code/game/machinery/bots/cleanbot.dm
@@ -97,8 +97,8 @@ text("<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>"))
 	return
 
 /obj/machinery/bot/cleanbot/Topic(href, href_list)
-
-	..()
+	if(..())
+		return 1
 	switch(href_list["operation"])
 		if("blood")
 			blood =!blood

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -135,13 +135,14 @@ Auto Patrol[]"},
 	return
 
 /obj/machinery/bot/ed209/Topic(href, href_list)
+	if(..())
+		return 1
 	if(lasercolor && (istype(usr,/mob/living/carbon/human)))
 		var/mob/living/carbon/human/H = usr
 		if((lasercolor == "b") && (istype(H.wear_suit, /obj/item/clothing/suit/redtag)))//Opposing team cannot operate it
-			return
+			return 1
 		else if((lasercolor == "r") && (istype(H.wear_suit, /obj/item/clothing/suit/bluetag)))
-			return
-	..()
+			return 1
 
 	switch(href_list["operation"])
 		if ("idcheck")

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -163,7 +163,8 @@
 			user << "<span class='danger'>[src] buzzes and beeps.</span>"
 
 /obj/machinery/bot/floorbot/Topic(href, href_list)
-	..()
+	if(..())
+		return 1
 	switch(href_list["operation"])
 		if("replace")
 			replacetiles = !replacetiles

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -182,8 +182,8 @@
 	return
 
 /obj/machinery/bot/medbot/Topic(href, href_list)
-	..()
-
+	if(..())
+		return 1
 	if(href_list["adj_threshold"])
 		var/adjust_num = text2num(href_list["adj_threshold"])
 		heal_threshold += adjust_num

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -260,9 +260,9 @@ obj/machinery/bot/mulebot/bot_reset()
 
 /obj/machinery/bot/mulebot/Topic(href, href_list)
 	if(..())
-		return
+		return 1
 	if (usr.stat)
-		return
+		return 1
 	if ((in_range(src, usr) && istype(loc, /turf)) || (istype(usr, /mob/living/silicon)))
 		usr.set_machine(src)
 

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -43,7 +43,8 @@
 	return "<br>Siren<A href='?src=\ref[src];operation=siren'>[siren ? "On" : "Off"]</A>"
 
 /obj/machinery/bot/secbot/beepsky/Topic(href, href_list)
-	..()
+	if(..())
+		return 1
 	if(href_list["operation"] == "siren")
 		siren = !siren
 		updateUsrDialog()
@@ -160,7 +161,7 @@ Auto Patrol: []"},
 "<A href='?src=\ref[src];operation=declarearrests'>[declare_arrests ? "Yes" : "No"]</A>",
 "<A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>" )
 
-	dat += get_additional_interact_options()
+		dat += get_additional_interact_options()
 
 	var/datum/browser/popup = new(user, "autosec", "Automatic Security Unit v1.6")
 	popup.set_content(dat)
@@ -168,8 +169,8 @@ Auto Patrol: []"},
 	return
 
 /obj/machinery/bot/secbot/Topic(href, href_list)
-
-	..()
+	if(..())
+		return 1
 
 	switch(href_list["operation"])
 		if("idcheck")

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -227,11 +227,11 @@ Class Procs:
 ////////////////////////////////////////////////////////////////////////////////////////////
 
 /mob/proc/canUseTopic() //TODO: once finished, place these procs on the respective mob files
-	return
+	return 0
 
 /mob/dead/observer/canUseTopic()
 	if(check_rights(R_ADMIN, 0))
-		return
+		return 0
 
 /mob/living/canUseTopic(atom/movable/M, be_close = 0, no_dextery = 0)
 	if(no_dextery)
@@ -243,40 +243,40 @@ Class Procs:
 
 /mob/living/carbon/human/canUseTopic(atom/movable/M, be_close = 0)
 	if(incapacitated() || lying )
-		return
+		return 0
 	if(!Adjacent(M))
 		if((be_close == 0) && (dna.check_mutation(TK)))
 			if(tkMaxRangeCheck(src, M))
 				return 1
-		return
+		return 0
 	if(!isturf(M.loc) && M.loc != src)
 		return
 	return 1
 
 /mob/living/silicon/ai/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat)
-		return
+		return 0
 	if(be_close && !in_range(M, src))
-		return
+		return 0
 	//stop AIs from leaving windows open and using then after they lose vision
 	//apc_override is needed here because AIs use their own APC when powerless
 	//get_turf_pixel() is because APCs in maint aren't actually in view of the inner camera
 	if(cameranet && !cameranet.checkTurfVis(get_turf_pixel(M)) && !apc_override)
-		return
+		return 0
 	return 1
 
 /mob/living/silicon/pai/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat)
-		return
+		return 0
 	if(be_close && !in_range(M, src) && !(paired == M))
-		return
+		return 0
 	return 1
 
 /mob/living/silicon/robot/canUseTopic(atom/movable/M, be_close = 0)
 	if(stat || lockcharge || stunned || weakened)
-		return
+		return 0
 	if(be_close && !in_range(M, src))
-		return
+		return 0
 	return 1
 
 /obj/machinery/attack_ai(mob/user)


### PR DESCRIPTION
Fixes #93. Fixed some bot interface buttons being usable when they should not be. Also made Beepsky's siren non-toggleable unless Beepsky is unlocked. Added some explicit "return 0"s in canUseTopic() proc where they were just "return"s.
