### PR TITLE
Fixed foam darts disappearing when they hit Beepsky

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -306,9 +306,8 @@
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(5, 1, src)
 			s.start()
-		..()
 		healthcheck()
-		return 1
+	..()
 	return
 
 /obj/machinery/bot/blob_act()

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -160,13 +160,13 @@ obj/machinery/bot/mulebot/bot_reset()
 	return
 
 /obj/machinery/bot/mulebot/bullet_act(obj/item/projectile/Proj)
-	if(..())
+	..()
+	if(Proj.damage && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		if(prob(50) && !isnull(load))
 			unload(0)
 		if(prob(25))
 			visible_message("<span class='danger'>Something shorts out inside [src]!</span>")
 			wires.RandomCut()
-
 
 /obj/machinery/bot/mulebot/attack_ai(mob/user)
 	user.set_machine(src)


### PR DESCRIPTION
Fixes issue #104. Made it so that the base class's bullet_act() is always called when a bot is hit by a projectile. This means that foam force darts and other reusable ammo fired at bots no longer disappears.  Also made Mulebots process damaging projectiles properly again, since they depended on the old code.
