### PR TITLE
Fixes Golem ID/Belt/Pockets not being removable.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -233,8 +233,8 @@
 		dat += "<tr><td><font color=grey><B>Uniform:</B></font></td><td><font color=grey>Obscured</font></td></tr>"
 	else
 		dat += "<tr><td><B>Uniform:</B></td><td><A href='?src=\ref[src];item=[slot_w_uniform]'>[(w_uniform && !(w_uniform.flags&ABSTRACT)) ? w_uniform : "<font color=grey>Empty</font>"]</A></td></tr>"
-
-	if(w_uniform == null || (slot_w_uniform in obscured) || (dna && dna.species.nojumpsuit))
+	
+	if((w_uniform == null || (slot_w_uniform in obscured)) && !(dna && dna.species.nojumpsuit))
 		dat += "<tr><td><font color=grey>&nbsp;&#8627;<B>Pockets:</B></font></td></tr>"
 		dat += "<tr><td><font color=grey>&nbsp;&#8627;<B>ID:</B></font></td></tr>"
 		dat += "<tr><td><font color=grey>&nbsp;&#8627;<B>Belt:</B></font></td></tr>"


### PR DESCRIPTION
Fixes #108 
**nojumpsuit** variable allows things to equip ID/Pocket/Belt without having a jumpsuit. Code checked if it was set and if it was, it DIDN'T show the remove menu thing for the item, the incorrect check was fixed.

This variable is used (set to 1) exclusively by the golem subspecies and nothing else.
