### PR TITLE
Drones pass through doors (+surprise)

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -48,6 +48,7 @@
 #define PASSBLOB		8
 #define PASSMOB			16
 #define LETPASSTHROW	32
+#define PASSDOOR		64
 
 //flags for species
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -1,6 +1,6 @@
 /obj/machinery/door
 	name = "door"
-	desc = "It opens and closes. On the bottom of it you see a small drone doggy door. It's big enough for Ian to pass through...somehow..."
+	desc = "It opens and closes. On the bottom is a small hatch for drones."
 	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door1"
 	anchored = 1

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -1,6 +1,6 @@
 /obj/machinery/door
 	name = "door"
-	desc = "It opens and closes."
+	desc = "It opens and closes. On the bottom of it you see a small drone doggy door. It's big enough for Ian to pass through...somehow..."
 	icon = 'icons/obj/doors/Doorint.dmi'
 	icon_state = "door1"
 	anchored = 1
@@ -76,8 +76,11 @@
 	move_update_air(T)
 
 /obj/machinery/door/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
-		return !opacity
+	if(istype(mover))
+		if(mover.checkpass(PASSDOOR))
+			return 1
+		else if(mover.checkpass(PASSGLASS))
+			return !opacity
 	return !density
 
 /obj/machinery/door/CanAtmosPass()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -74,7 +74,7 @@
 	return
 
 /obj/machinery/door/window/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSGLASS) || mover.checkpass(PASSDOOR)))
 		return 1
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -388,6 +388,7 @@
 	response_help  = "pets"
 	response_disarm = "bops"
 	response_harm   = "kicks"
+	pass_flags = PASSDOOR
 
 /mob/living/simple_animal/pet/dog/corgi/Ian/Life()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -25,7 +25,7 @@
 	speed = 0
 	ventcrawler = 2
 	density = 0
-	pass_flags = PASSTABLE | PASSMOB
+	pass_flags = PASSTABLE | PASSMOB | PASSDOOR
 	sight = (SEE_TURFS | SEE_OBJS)
 	status_flags = (CANPUSH | CANSTUN | CANWEAKEN)
 	gender = NEUTER


### PR DESCRIPTION
Implementation of #110
Preamble : CanPass system is such a cool and well designed piece of functionality :+1:

Added new PASSDOOR flag that can be added to mobs 'pass_flags' variable. If the mob has it, it can pass through any airlocks and window doors, but not firedoors (the vertical ones).
Also includes lore friendly text!

BONUS FEATURE : A certain unique someone can pass through the _doggy_ drone door as well! Stay on your toes, HoP!
