### PR TITLE
Fixes reagent runtimes

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -4,8 +4,9 @@
 
 #define REM REAGENTS_EFFECT_MULTIPLIER
 
-//The reaction procs must ALWAYS set src = null, this detaches the proc from the object (the reagent)
-//so that it can continue working when the reagent is deleted while the proc is still active.
+//Disregard the two line-comments below! They remain only for posterity! Do not set src to null unless you are doing a sleep() or spawn(), and even then, store it in a var and restore it after!
+////The reaction procs must ALWAYS set src = null, this detaches the proc from the object (the reagent)
+////so that it can continue working when the reagent is deleted while the proc is still active.
 
 
 //Various reagents
@@ -38,7 +39,7 @@
 	if(!istype(M))
 		return 0
 	var/datum/reagent/self = src
-	src = null
+
 
 	if(method == VAPOR) //smoke, foam, spray
 		if(M.reagents)
@@ -49,11 +50,9 @@
 	return 1
 
 /datum/reagent/proc/reaction_obj(obj/O, volume)
-	src = null
 	return
 
 /datum/reagent/proc/reaction_turf(turf/T, volume)
-	src = null
 	return
 
 /datum/reagent/proc/on_mob_life(mob/living/M)

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -7,7 +7,6 @@
 
 /datum/reagent/blood/reaction_mob(mob/M, method=TOUCH, reac_volume)
 	var/datum/reagent/blood/self = src
-	src = null
 	if(self.data && self.data["viruses"])
 		for(var/datum/disease/D in self.data["viruses"])
 
@@ -52,7 +51,6 @@
 	if(!istype(T))
 		return
 	var/datum/reagent/blood/self = src
-	src = null
 	if(reac_volume < 3)
 		return
 	//var/datum/disease/D = self.data["virus"]
@@ -97,7 +95,6 @@
 
 /datum/reagent/vaccine/reaction_mob(mob/M, method=TOUCH, reac_volume)
 	var/datum/reagent/vaccine/self = src
-	src = null
 	if(islist(self.data) && method == INGEST)
 		for(var/datum/disease/D in M.viruses)
 			if(D.GetDiseaseID() in self.data)
@@ -131,7 +128,6 @@
 			F.dirt = 0
 
 	var/CT = cooling_temperature
-	src = null
 	if(reac_volume >= 10)
 		T.MakeSlippery()
 
@@ -153,7 +149,6 @@
  */
 
 /datum/reagent/water/reaction_obj(obj/O, reac_volume)
-	src = null
 	O.color = initial(O.color)
 
 	if(istype(O,/obj/item))
@@ -262,7 +257,6 @@
 
 /datum/reagent/lube/reaction_turf(turf/simulated/T, reac_volume)
 	if (!istype(T)) return
-	src = null
 	if(reac_volume >= 1)
 		T.MakeSlippery(2)
 
@@ -396,7 +390,6 @@
 	color = "#13BC5E" // rgb: 19, 188, 94
 
 /datum/reagent/aslimetoxin/reaction_mob(mob/M, method=TOUCH, reac_volume)
-	src = null
 	if(method != TOUCH)
 		M.ForceContractDisease(new /datum/disease/transformation/slime(0))
 
@@ -478,7 +471,6 @@
 	color = "#1C1300" // rgb: 30, 20, 0
 
 /datum/reagent/carbon/reaction_turf(turf/T, reac_volume)
-	src = null
 	if(!istype(T, /turf/space))
 		new /obj/effect/decal/cleanable/dirt(T)
 
@@ -554,7 +546,6 @@
 	return
 
 /datum/reagent/radium/reaction_turf(turf/T, reac_volume)
-	src = null
 	if(reac_volume >= 3)
 		if(!istype(T, /turf/space))
 			var/obj/effect/decal/cleanable/reagentdecal = new/obj/effect/decal/cleanable/greenglow(T)
@@ -599,7 +590,6 @@
 	..()
 
 /datum/reagent/uranium/reaction_turf(turf/T, reac_volume)
-	src = null
 	if(reac_volume >= 3)
 		if(!istype(T, /turf/space))
 			var/obj/effect/decal/cleanable/reagentdecal = new/obj/effect/decal/cleanable/greenglow(T)
@@ -733,7 +723,6 @@
 	color = "#535E66" // rgb: 83, 94, 102
 
 /datum/reagent/nanites/reaction_mob(mob/M, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
-	src = null
 	if(method==PATCH || method==INGEST || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		M.ForceContractDisease(new /datum/disease/transformation/robot(0))
 
@@ -744,7 +733,6 @@
 	color = "#535E66" // rgb: 83, 94, 102
 
 /datum/reagent/xenomicrobes/reaction_mob(mob/M, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
-	src = null
 	if(method==PATCH || method==INGEST || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		M.ContractDisease(new /datum/disease/transformation/xeno(0))
 

--- a/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
@@ -7,7 +7,6 @@
 	color = "#673910" // rgb: 103, 57, 16
 
 /datum/reagent/thermite/reaction_turf(turf/T, reac_volume)
-	src = null
 	if(reac_volume >= 1 && istype(T, /turf/simulated/wall))
 		var/turf/simulated/wall/Wall = T
 		if(istype(Wall, /turf/simulated/wall/r_wall))

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -33,7 +33,6 @@
 		return
 	if(!istype(M) || !M.dna)
 		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
-	src = null
 	if((method==VAPOR && prob(min(33, reac_volume))) || method==INGEST || method == PATCH)
 		randmuti(M)
 		if(prob(98))
@@ -66,14 +65,12 @@
 	return
 
 /datum/reagent/toxin/plasma/reaction_obj(obj/O, reac_volume)
-	src = null
 	if((!O) || (!reac_volume))	return 0
 	O.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C, reac_volume)
 	if(!istype(holder.my_atom, /obj/effect/effect/smoke/chem))
 		O.report_reaction("plasma")
 
 /datum/reagent/toxin/plasma/reaction_turf(turf/simulated/T, reac_volume)
-	src = null
 	if(istype(T))
 		T.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C, reac_volume)
 		if(!istype(holder.my_atom, /obj/effect/effect/smoke/chem))
@@ -193,7 +190,6 @@
 		SV.on_chem_effect(src)
 
 /datum/reagent/toxin/plantbgone/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	src = null
 	if(method == VAPOR)
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
@@ -216,7 +212,6 @@
 	toxpwr = 1
 
 /datum/reagent/toxin/pestkiller/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	src = null
 	if(method == VAPOR)
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
@@ -674,7 +669,6 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 	reac_volume = round(reac_volume,0.1)
 	for(var/obj/O in T)
 		O.acid_act(acidpwr, reac_volume)
-	src = null
 
 /datum/reagent/toxin/acid/fluacid
 	name = "Fluorosulfuric acid"


### PR DESCRIPTION
Fixes 4/6 runtimes in #109 (the first 3 and the last one). removes some "src = null" from reagent code, which was causing null pointer runtimes when the reagents were put in a human's bloodstream.

If you know why these lines were in the code, please speak up and tell me why I am wrong.
