### PR TITLE
Fix for syndicate borgs being unable to use grenade launcher

### DIFF
--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -25,6 +25,7 @@
 	icon = 'icons/mecha/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi
+	pin = /obj/item/device/firing_pin
 
 /obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg/attack_self()
 	return


### PR DESCRIPTION
Recent escapades as a syndicate borg have indicated problems with their (in)ability to use the internal grenade launcher, this has been fixed now.

Changed fire pin to standard.
