### PR TITLE
Port of /tg/ Nuclear Operative challenge mode

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -116,7 +116,11 @@
 	synd_mind.current.real_name = "[syndicate_name()] [leader_title]"
 	synd_mind.current << "<B>You are the Syndicate [leader_title] for this mission. You are responsible for the distribution of telecrystals and your ID is the only one who can open the launch bay doors.</B>"
 	synd_mind.current << "<B>If you feel you are not up to this task, give your ID to another operative.</B>"
-
+	synd_mind.current << "<B>In your hand you will find a special item capable of triggering a greater challenge for your team. Examine it carefully and consult with your fellow operatives before activating it.</B>"
+	
+	var/obj/item/device/nuclear_challenge/challenge = new /obj/item/device/nuclear_challenge
+	synd_mind.current.equip_to_slot_or_del(challenge, slot_r_hand)
+	
 	var/list/foundIDs = synd_mind.current.search_contents_for(/obj/item/weapon/card/id)
 	if(foundIDs.len)
 		for(var/obj/item/weapon/card/id/ID in foundIDs)

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,0 +1,48 @@
+#define CHALLENGE_TC_PER_PLAYER 5.6
+#define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_MIN_PLAYERS 25
+#define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+
+/obj/item/device/nuclear_challenge
+	name = "Declaration of War (Challenge Mode)"
+	icon_state = "gangtool-red"
+	item_state = "walkietalkie"
+	desc = "Use to send a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
+			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
+			Must be used within five minutes, or your benefactors will lose interest."
+
+/obj/item/device/nuclear_challenge/attack_self(mob/living/user)
+	if(player_list.len < CHALLENGE_MIN_PLAYERS)
+		user << "The enemy crew is too small to be worth declaring war on."
+		return
+	if(user.z != ZLEVEL_CENTCOM)
+		user << "You have to be at your base to use this."
+		return
+
+	if(world.time > CHALLENGE_TIME_LIMIT)
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
+		return
+
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for your assault.", "Declare war?", "Yes", "No")
+	if(are_you_sure == "No")
+		user << "On second thought, the element of surprise isn't so bad after all."
+		return
+
+	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
+	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/Alarm.ogg')
+	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
+
+	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
+		S.challenge = TRUE
+
+	var/obj/item/device/radio/uplink/U = new(get_turf(user))
+	U.hidden_uplink.uplink_owner = "[user.key]"
+	U.hidden_uplink.uses = round(CHALLENGE_TC_PER_PLAYER*player_list.len)
+	config.shuttle_refuel_delay = max(config.shuttle_refuel_delay, CHALLENGE_SHUTTLE_DELAY)
+	qdel(src)
+
+
+#undef CHALLENGE_TELECRYSTALS
+#undef CHALLENGE_TIME_LIMIT
+#undef CHALLENGE_MIN_PLAYERS
+#undef CHALLENGE_SHUTTLE_DELAY

--- a/code/game/machinery/computer/syndicate_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_shuttle.dm
@@ -1,3 +1,5 @@
+#define SYNDICATE_CHALLENGE_TIMER 12000
+
 /obj/machinery/computer/shuttle/syndicate
 	name = "syndicate shuttle terminal"
 	icon_screen = "syndishuttle"
@@ -5,7 +7,15 @@
 	req_access = list(access_syndicate)
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_z3;syndicate_z4;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s"
+	var/challenge = FALSE
 
+/obj/machinery/computer/shuttle/syndicate/Topic(href, href_list)
+	if(href_list["move"])
+		if(challenge && world.time < SYNDICATE_CHALLENGE_TIMER)
+			usr << "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least [round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] more minutes to allow them to prepare.</span>"
+			return 0
+	..()
+	
 /obj/machinery/computer/shuttle/syndicate/recall
 	name = "syndicate shuttle recall terminal"
 	possible_destinations = "syndicate_away"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -350,6 +350,7 @@
 #include "code\game\gamemodes\meteor\meteors.dm"
 #include "code\game\gamemodes\monkey\monkey.dm"
 #include "code\game\gamemodes\nuclear\nuclear.dm"
+#include "code\game\gamemodes\nuclear\nuclear_challenge.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"


### PR DESCRIPTION
All credit to KorPhareon's implementation in tgstation/-tg-station#13640
1. Minimal player requirement is 25 players,
2. 5.6 TC per player on server given upon initiation of challenge mode (no cap on TC given).
3. Syndicate shuttle movement delayed until 20 minutes since round start have passed.
4. Station can call CentComm shuttle only after 25 minutes since round start have passed (Nuke Ops have at least 5 minutes of (hopefully) uninterrupted slaughter).
5. Oh, right, also, when you get the "Challenge or not" prompt, it tells you how many extra TC you will receive.

Upon spawning, the Nuke Op leader gets a gang-looking device that you can use to send the announcement (Yes/No prompt is given). After activation, a CentComm announcement is sent, telling that Nuke Ops want to rekt you and the leader is given another radio with the bonus TC.

Comments about balancing are very welcome. Let's hope to actually see Maulers and stuff.

EDIT: I've tested this locally, btw, by editing the player requirements in the  code/game/gamemodes/nuclear/nuclear.dm file.
