### PR TITLE
Major Glowshroom nerfs, some bugfixes.

### DIFF
--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -19,8 +19,17 @@
 /obj/effect/glowshroom/single
 	yield = 0
 
-/obj/effect/glowshroom/New()
-	..()
+/obj/effect/glowshroom/New(var/newLoc, var/newPotency = -1, var/newYield = -1, var/newDelay = -1, var/newEndurance = -1)
+	..(newLoc)
+	if(newPotency != -1)
+		potency = newPotency
+	if(newYield != -1)
+		yield = newYield
+	if(newDelay != -1)
+		delay = newDelay
+	if(newEndurance != -1)
+		endurance = newEndurance
+
 	SetLuminosity(round(potency/10))
 	dir = CalcDir()
 	if(!floor)
@@ -36,9 +45,9 @@
 		icon_state = "glowshroom[rand(1,3)]"
 	else //if on the floor, glowshroom on-floor sprite
 		icon_state = "glowshroomf"
-
-	spawn(delay)
-		Spread()
+	if(yield > 0)
+		spawn(delay)
+			Spread()
 
 /obj/effect/glowshroom/proc/Spread()
 	set background = BACKGROUND_ENABLED
@@ -71,11 +80,7 @@
 			if(shroomCount >= placeCount)
 				continue
 
-			var/obj/effect/glowshroom/child = new /obj/effect/glowshroom(newLoc)//The baby mushrooms have different stats :3
-			child.potency = max(potency+rand(-3,6), 0)
-			child.yield = max(yield+rand(-1,2), 0)
-			child.delay = max(delay+rand(-30,60), 0)
-			child.endurance = max(endurance+rand(-3,6), 1)
+			var/obj/effect/glowshroom/child = new /obj/effect/glowshroom(newLoc, max(potency+rand(-3,6), 0), max(yield+rand(-1,0), 0), max(delay+rand(-30,60), 0), max(endurance+rand(-3,6), 1))
 			child.generation = generation+1
 			child.desc = "This is a [child.generation]\th generation glowshroom!"//I added this for testing, but I figure I'll leave it in.
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -1197,11 +1197,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/attack_self(mob/user)
 	if(istype(user.loc,/turf/space))
 		return
-	var/obj/effect/glowshroom/planted = new /obj/effect/glowshroom(user.loc)
-	planted.delay = planted.delay - production * 100 //So the delay goes DOWN with better stats instead of up. :I
-	planted.endurance = endurance
-	planted.yield = yield
-	planted.potency = potency
+	new /obj/effect/glowshroom(user.loc, potency, yield, max(1200 - production * 100, 0), endurance)
 	qdel(src)
 	user << "<span class='notice'>You plant the glowshroom.</span>"
 


### PR DESCRIPTION
Response to issue #185.
Significantly nerfs glowshroom spread in a desperate attempt to keep glowshrooms in the game. Also fixes some long-standing bugs where stats would not have the proper effects on later generations of glowshrooms.
