### PR TITLE
Changeling fixes (Transformation/Monkeyize)

### DIFF
--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -974,7 +974,7 @@
 
 /datum/dna/proc/is_same_as(datum/dna/D)
 	if(uni_identity == D.uni_identity && struc_enzymes == D.struc_enzymes && real_name == D.real_name)
-		if(species == D.species && features == D.features && blood_type == D.blood_type)
+		if(species.type == D.species.type && features == D.features && blood_type == D.blood_type)
 			return 1
 	return 0
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -346,7 +346,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 		user << "<span class='warning'>We could gain no benefit from absorbing a lesser creature.</span>"
 		return
 	if(has_dna(target.dna))
-		user << "<span class='warning'>We already have this DNA in storage!</span>"
+		user << "<span class='warning'>We refresh this DNA with new information!</span>"
 	if(!check_dna_integrity(target))
 		user << "<span class='warning'>[target] is not compatible with our biology.</span>"
 		return
@@ -424,8 +424,18 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	user.real_name = chosen_prof.name
 	user.dna = chosen_dna
 	hardset_dna(user, null, null, null, null, chosen_dna.species.type, chosen_dna.features)
+	user.gender = chosen_prof.gender
+	user.skin_tone = chosen_prof.skin_tone
+	user.hair_color = chosen_prof.hair_color
+	user.hair_style = chosen_prof.hair_style
+	user.facial_hair_color = chosen_prof.facial_hair_color
+	user.facial_hair_style = chosen_prof.facial_hair_style
+	user.eye_color = chosen_prof.eye_color
+	user.features = chosen_prof.features
+	
 	domutcheck(user)
-	updateappearance(user)
+	user.update_body()
+	user.update_hair()
 
 	//vars hackery. not pretty, but better than the alternative.
 	for(var/slot in slots)
@@ -469,7 +479,6 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	var/list/item_color_list = list()
 	var/list/item_state_list = list()
 	
-	//Xthedark : Human/Etc appearence data, seems we'll have to save/set this manually
 	var/gender = null
 	var/skin_tone = null
 	var/hair_color = null

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -53,8 +53,10 @@
 	user.visible_message("<span class='danger'>[user] sucks the fluids from [target]!</span>", "<span class='notice'>We have absorbed [target].</span>")
 	target << "<span class='userdanger'>You are absorbed by the changeling!</span>"
 
-	if(!changeling.has_dna(target.dna))
-		changeling.add_profile(target, user)
+	if(changeling.has_dna(target.dna))
+		changeling.remove_profile(target)
+		changeling.absorbedcount--
+	changeling.add_profile(target, user)
 
 	if(user.nutrition < NUTRITION_LEVEL_WELL_FED)
 		user.nutrition = min((user.nutrition + target.nutrition), NUTRITION_LEVEL_WELL_FED)

--- a/code/game/gamemodes/changeling/powers/lesserform.dm
+++ b/code/game/gamemodes/changeling/powers/lesserform.dm
@@ -11,7 +11,12 @@
 	if(!user || user.notransform)
 		return 0
 	user << "<span class='warning'>Our genes cry out!</span>"
-
+	
+	//Delete "flesh" items before monkeyizing
+	for(var/slot in slots)
+		if(istype(user.vars[slot], slot2type[slot]))
+			qdel(user.vars[slot])
+				
 	user.monkeyize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPSE | TR_KEEPSRC)
 
 	// Human-form power now handled in monkeyize()

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -186,7 +186,6 @@
 /obj/effect/proc_holder/changeling/sting/extract_dna/sting_action(mob/user, mob/living/carbon/human/target)
 	add_logs(user, target, "stung", "extraction sting")
 	if((user.mind.changeling.has_dna(target.dna)))
-		world << "About to refresh the current DNA"
 		user.mind.changeling.remove_profile(target)
 		user.mind.changeling.absorbedcount--
 	user.mind.changeling.add_profile(target, user)

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -185,8 +185,11 @@
 
 /obj/effect/proc_holder/changeling/sting/extract_dna/sting_action(mob/user, mob/living/carbon/human/target)
 	add_logs(user, target, "stung", "extraction sting")
-	if(!(user.mind.changeling.has_dna(target.dna)))
-		user.mind.changeling.add_profile(target, user)
+	if((user.mind.changeling.has_dna(target.dna)))
+		world << "About to refresh the current DNA"
+		user.mind.changeling.remove_profile(target)
+		user.mind.changeling.absorbedcount--
+	user.mind.changeling.add_profile(target, user)
 	feedback_add_details("changeling_powers","ED")
 	return 1
 


### PR DESCRIPTION
1. Fixes is_same DNA not checking species equality correctly.
2. Changelings no longer drop their "flesh" (imitation items) when they monkeyize. Issue #174 
3. Transformation now correctly applies hair/eye color/etc (still no underwear though).
4. If you DNA sting/Absorb someone whose DNA you already have, you refresh that profile (basically means you get their current clothes).
