### PR TITLE
No-slip shoes and active magboots don't slip on anything

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -23,6 +23,7 @@
 #define EARBANGPROTECT		1024
 
 #define NOSLIP		1024 		//prevents from slipping on wet floors, in space etc (NOTE: flag shared with THICKMATERIAL for external suits and helmet)
+#define SUPERNOSLIP 2048		//precents from slipping on space lube
 
 #define OPENCONTAINER	4096	// is an open container for chemistry purposes
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -21,10 +21,10 @@
 
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
 	if(src.magpulse)
-		src.flags &= ~NOSLIP
+		src.flags &= ~SUPERNOSLIP
 		src.slowdown = SHOES_SLOWDOWN
 	else
-		src.flags |= NOSLIP
+		src.flags |= SUPERNOSLIP
 		src.slowdown = slowdown_active
 	magpulse = !magpulse
 	icon_state = "[magboot_state][magpulse]"
@@ -33,7 +33,7 @@
 	user.update_gravity(user.mob_has_gravity())
 
 /obj/item/clothing/shoes/magboots/negates_gravity()
-	return flags & NOSLIP
+	return flags & SUPERNOSLIP
 
 /obj/item/clothing/shoes/magboots/examine(mob/user)
 	..()

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -13,7 +13,7 @@
 	icon_state = "brown"
 	item_state = "brown"
 	permeability_coefficient = 0.05
-	flags = NOSLIP
+	flags = SUPERNOSLIP
 	origin_tech = "syndicate=3"
 	burn_state = -1 //Won't burn in fires
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -33,7 +33,7 @@
 
 /mob/living/carbon/human/experience_pressure_difference()
 	playsound(src, 'sound/effects/space_wind.ogg', 50, 1)
-	if(shoes && (shoes.flags&NOSLIP || shoes.flags%SUPERNOSLIP))
+	if(shoes && (shoes.flags&NOSLIP || shoes.flags&SUPERNOSLIP))
 		return 0
 	. = ..()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -25,13 +25,15 @@
 
 
 /mob/living/carbon/human/slip(s_amount, w_amount, obj/O, lube)
+	if(isobj(shoes) && shoes.flags&SUPERNOSLIP)
+		return 0
 	if(isobj(shoes) && (shoes.flags&NOSLIP) && !(lube&GALOSHES_DONT_HELP))
 		return 0
 	.=..()
 
 /mob/living/carbon/human/experience_pressure_difference()
 	playsound(src, 'sound/effects/space_wind.ogg', 50, 1)
-	if(shoes && shoes.flags&NOSLIP)
+	if(shoes && (shoes.flags&NOSLIP || shoes.flags%SUPERNOSLIP))
 		return 0
 	. = ..()
 


### PR DESCRIPTION
Issue #195 
There you go, lube nerfed for anyone other than traitors, maybe now nuke ops/traitors will buy the damn shoes sometimes, eh?
Doesn't slip on lube/soap/clown pda/etc. Go nuts.
