### PR TITLE
Entering Mech no longer minimizes your HUD/Create X panel is not populated upon first open

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -766,10 +766,6 @@
 		H.reset_view(src)
 		H.stop_pulling()
 		H.forceMove(src)
-		if(H.hud_used)
-			last_user_hud = H.hud_used.hud_shown
-			H.hud_used.show_hud(HUD_STYLE_REDUCED)
-
 		occupant = H
 		add_fingerprint(H)
 		GrantActions(H, human_occupant=1)

--- a/html/create_object.html
+++ b/html/create_object.html
@@ -55,7 +55,6 @@
 		var timeoutId = -1;
 		
 		document.spawner.filter.focus();
-		populateList(objects);
 		
 		function populateList(from_list)
 		{


### PR DESCRIPTION
As per title, should fix #219 and #60 since the icons are now visible when you enter the mech.
Create Object/Mob command for admins no longer loads a populated list, meaning it doesn't take ages for Create Object window to load in.

Currently, there's still the problem with exiting/entering Mech causing it to take ages to regenerate icons for the mech abilities, but I'm pretty sure this is not caused by the code by rather by processing speed set on the server, by all means, correct me if I'm wrong.
