### PR TITLE
Cybermen updates v3

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -51,5 +51,5 @@ var/list/be_special_flags = list(
 	"Abductor" = BE_ABDUCTOR,
 	"Revenant" = BE_REVENANT,
 	"Shadowling" = BE_SHADOWLING,
-	"Cyberman" = BE_SHADOWLING
+	"Cyberman" = BE_CYBERMAN
 	)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -483,12 +483,13 @@
 		text += "<b>CYBERMAN</b>|<a href='?src=\ref[src];cyberman=clear'>human</a>"
 	else
 		text += "<a href='?src=\ref[src];cyberman=cyberman'>cyberman</a>|<b>HUMAN</b>"
-
-	if(current && current.client && (BE_CYBERMAN in current.client.prefs.be_special))
+	text += "|Pref unknown"
+/*
+	if(current && current.client/* && current.client.prefs.be_special & BE_CYBERMAN*/)//the pref doesn't work because the number is too big for the & operator.
 		text += "|Enabled in Prefs"
 	else
 		text += "|Disabled in Prefs"
-
+*/
 	sections["cyberman"] = text
 
 	/** MONKEY ***/

--- a/code/game/gamemodes/cybermen/cybermen.dm
+++ b/code/game/gamemodes/cybermen/cybermen.dm
@@ -21,16 +21,7 @@
 #warn Warning: Cybermen debug text and abilities are enabled
 #endif
 
-/datum/game_mode
-	var/cybermen_win = 0
-	var/list/datum/mind/cybermen = list()
-	var/list/datum/objective/cybermen/cybermen_objectives = list()
-	var/datum/objective/cybermen/queued_cybermen_objective = null
-	var/list/obj/effect/cyberman_hack/active_cybermen_hacks = list()
-	var/list/cybermen_hacked_objects = list()//used for objectives, might someday be used for faster hacks on things that have already been hacked.
-	var/list/datum/tech/cybermen_research_downloaded = list()//used for research objectives. May do other things as well someday.
-	var/list/cybermen_access_downloaded = list()//have to use this because otherwise you could hack an ID and then change its access to get the objective, which makes no sense.
-
+var/datum/cyberman_network/cyberman_network
 
 /datum/game_mode/cybermen
 	name = "cybermen"
@@ -51,7 +42,8 @@
 	world << "The gamemode is Cybermen."
 
 /datum/game_mode/cybermen/pre_setup()
-
+	if(!cyberman_network)
+		new /datum/cyberman_network()
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
@@ -66,7 +58,7 @@
 
 	while(cybermen_num)
 		var/datum/mind/cyberman = pick(antag_candidates)
-		cybermen += cyberman
+		cyberman_network.cybermen += cyberman
 		cyberman.cyberman = new /datum/cyberman_datum()
 		antag_candidates -= cyberman
 		cyberman.special_role = "Cyberman"
@@ -77,25 +69,176 @@
 /datum/game_mode/cybermen/post_setup()
 	sleep(10)
 
-	for(var/datum/mind/cyberman in cybermen)
+	for(var/datum/mind/cyberman in cyberman_network.cybermen)
 		log_game("[cyberman.key] (ckey) has been selected as a Cyberman.")
 		spawn(9)
-			cybermen -= cyberman
+			cyberman_network.cybermen -= cyberman
 			add_cyberman(cyberman, "<span class='boldannounce'><b><font size=3>You are a Cyberman!</font></b></span>\n<b>Any other Cybermen are your allies. Work together to complete your objectives. You will be given a total of four objectives, each revealed upon completion of the previous objective.</b>")
-	generate_cybermen_objective(1)
 	spawn(10)
-		display_current_cybermen_objective()
+		cyberman_network.display_current_cybermen_objective()
 	..()
 	return
 
-/datum/game_mode/cybermen/process()
+/*
+/datum/game_mode/proc/is_cyberman(datum/mind/mind)//fast and simple one
+	return mind && mind.cyberman && (mind in cybermen)
+*/
+
+/datum/game_mode/proc/is_cyberman(datum/mind/mind)//better for logging errors
+	if(!mind || !cyberman_network)
+		return 0
+	var/in_cybermen = (mind in cyberman_network.cybermen)
+	if((mind.cyberman && !in_cybermen) || (!mind.cyberman && in_cybermen))
+		var/message = mind.cyberman ? "[mind] was found to have an initialized cyberman datum, but is not a registered cyberman. Please report this bug to a coder." : "[mind] was found to not have an initialized cyberman datum, but is a registered cyberman. Please report this bug to a coder."
+		log_game(message)
+		return 0
+	return mind.cyberman
+
+/datum/game_mode/proc/add_cyberman(var/datum/mind/cyberman, var/message_override)
+	if(!cyberman_network)
+		new /datum/cyberman_network()
+	if(is_cyberman(cyberman))
+		return
+	cyberman_network.cybermen += cyberman//careful this doesn't happen twice.
+	cyberman.cyberman = new /datum/cyberman_datum()
+	cyberman.special_role = "cyberman"
+	cyberman.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Became a cyberman</span>"
+
+	update_cybermen_icons_add(cyberman)
+	if(message_override)
+		cyberman.current << message_override
+	else
+		cyberman.current << "<span class='boldannounce'><b><font size=3>You are now a Cyberman! Work with your fellow cybermen and do not harm them.</font></b></span>"
+
+	var/mob/living/carbon/human/H = cyberman.current
+	if(cyberman.assigned_role == "Clown")
+		H << "<span class='notice'>Your superior Cyberman form has allowed you to overcome your clownish genetics.</span>"
+		H.dna.remove_mutation(CLOWNMUT)
+	if(isloyal(H))
+		H << "<span class='notice'>Your loyalty implant has been deactivated, but not destroyed. While scanners will show that it is still active, you are no longer loyal to Nanotrasen.</span>"//I personnally am not a fan of this, but Alblaka said it so that's what I've done.
+
+	cyberman.current << "<span class='notice'>As a Cyberman, hacking is your most valuable ability. Click on \'Prepare Hacking\' in the Cybermen tab to use it.</span>"
+	cyberman.current << "<span class='notice'>You can use the Cyberman Broadcast to undetectably communicate with your fellow Cybermen. You can also use robot talk with .b, but this will alert any unhacked cyborgs or AIs to your presence.</span>"
+	cyberman.current << "<span class='notice'>\n\"Cybermen\" is an experimental gamemode. If you find any bugs, please submit an issue on the server's github. If a bug prevents you from completing an objective, or you are not properly assigned an objective, contact an admin via ahelp.</span>"
+	cyberman_network.display_all_cybermen_objectives(cyberman)
+
+/datum/game_mode/proc/remove_cyberman(datum/mind/cyberman, var/message_override)
+	if(!is_cyberman(cyberman) )
+		return
+	//drop all installed parts (except limbs)
+	for(var/obj/item/weapon/stock_parts/capacitor/P in cyberman.cyberman.upgrades_installed)
+		P.loc = cyberman.current.loc
+		cyberman.cyberman.upgrades_installed -= P
+	qdel(cyberman.cyberman)
+	cyberman.cyberman = null//redundant but doesn't hurt to be safe.
+	cyberman_network.cybermen -= cyberman
+	cyberman.current.attack_log += "\[[time_stamp()]\] <span class='danger'>De-Cybermanized</span>"
+	cyberman.special_role = null
+
+	update_cybermen_icons_remove(cyberman)
+	var/mob/living/carbon/human/H = cyberman.current
+	if(issilicon(H))
+		H.audible_message("<span class='notice'>[H] lets out a short blip.</span>", "<span class='userdanger'>You have been turned into a robot! You are no longer a cyberman! Though you try, you cannot remember anything about the cybermen or your time as one...</span>")
+	else
+		H.visible_message("<span class='big'>[H] looks like their mind is their own again!</span>", message_override ? message_override : "<span class='userdanger'>Your mind is your own again! You are no longer a cyberman! Though you try, you cannot remember anything about the cybermen or your time as one...</span>")
+		if(isloyal(H))
+			H << "<span class='notice'>Your loyalty implant has been re-activated - you are once again unfailingly loyal to Nanotrasen.</span>"
+
+/datum/game_mode/cybermen/check_finished()
+	return ..() || cyberman_network.cybermen_win
+
+/datum/game_mode/cybermen/check_win()
+	return cyberman_network.cybermen_win
+
+/datum/game_mode/cybermen/declare_completion()
+	..()
+	if(!cyberman_network.cybermen_win && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
+		world << "<span class='redtext'>The Cybermen failed to take control of the station!</span>"
+	else if(cyberman_network.cybermen_win && station_was_nuked)
+		world << "<span class='greentext'>The Cybermen win! They acivated the station's self-destruct device!</span>"
+	else if(cyberman_network.cybermen_win)
+		world << "<span class='greentext'>The Cybermen win! They have exterminated or stranded all of the non-cybermen!</span>"
+	else
+		world << "<span class='redtext'>The Cybermen have failed!</span>"
+
+	world << "<br><span class='big'><b>The Cybermens' Objectives were:</b></span>"
+	var/datum/objective/cybermen/O
+	for(var/i = 1 to cyberman_network.cybermen_objectives.len-1)
+		O = cyberman_network.cybermen_objectives[i]
+		if(O)
+			world << "Phase [i]:[O.phase]"
+			world << "[O.explanation_text]"
+			world << "<font color='green'><b>Completed</b></font><br>"
+	O = cyberman_network.cybermen_objectives[cyberman_network.cybermen_objectives.len]
+	world << "Phase [cyberman_network.cybermen_objectives.len]:[O.phase]"
+	world << "[O.explanation_text]"
+	world << (O.check_completion() ? "<font color='green'><b>Completed</b></font><br>" : "<font color='red'><b>Failed</b></font>")
+	return 1
+
+/datum/game_mode/proc/auto_declare_completion_cybermen()
+	if(cyberman_network && cyberman_network.cybermen.len > 0)
+		var/text = ""
+		text += "<br><span class='big'><b>The Cybermen were:</b></span>"
+		for(var/datum/mind/cyberman in cyberman_network.cybermen)
+			text += printplayer(cyberman)
+		world << text
+
+datum/game_mode/proc/update_cybermen_icons_add(datum/mind/cyberman)
+	var/datum/atom_hud/antag/cyberman_hud = huds[ANTAG_HUD_CYBERMEN]
+	cyberman_hud.join_hud(cyberman.current)
+	set_antag_hud(cyberman.current, "cybermen")
+
+datum/game_mode/proc/update_cybermen_icons_remove(datum/mind/cyberman)
+	var/datum/atom_hud/antag/cyberman_hud = huds[ANTAG_HUD_CYBERMEN]
+	cyberman_hud.leave_hud(cyberman.current)
+	set_antag_hud(cyberman.current, null)
+
+////////////////////////////////////////////////////////
+//CYBERMAN NETWORK
+////////////////////////////////////////////////////////
+//handles processing objectives and hacking
+
+/datum/cyberman_network
+	var/cybermen_win = 0
+	var/list/datum/mind/cybermen = list()
+	var/list/datum/objective/cybermen/cybermen_objectives = list()
+	var/datum/objective/cybermen/queued_cybermen_objective = null
+	var/list/obj/effect/cyberman_hack/active_cybermen_hacks = list()
+	var/list/cybermen_hacked_objects = list()//used for objectives, might someday be used for faster hacks on things that have already been hacked.
+	var/list/datum/tech/cybermen_research_downloaded = list()//used for research objectives. May do other things as well someday.
+	var/list/cybermen_access_downloaded = list()//have to use this because otherwise you could hack an ID and then change its access to get the objective, which makes no sense.
+	var/list/hacking_log = list()
+	var/list/cyberman_broadcast_log = list()
+
+/datum/cyberman_network/New()
+	cyberman_network = src
+	SSobj.processing += src
+	generate_cybermen_objective(1)//there must always be an objective or it will cause runtimes.
+	message_admins("The Cyberman Network has been initialized.")
+
+/datum/cyberman_network/process(seconds)
+	process_cyberman_hacking()
+	process_cyberman_objectives()
+
+/datum/cyberman_network/proc/log_hacking(var/message, var/high_priority = 0)
+	if(high_priority)
+		message_admins(message)
+	hacking_log += "\[[time_stamp()]\][message]"
+
+/datum/cyberman_network/proc/log_broadcast(var/message, var/high_priority = 0)
+	if(high_priority)
+		message_admins(message)
+	cyberman_broadcast_log += "\[[time_stamp()]\][message]"
+
+/datum/cyberman_network/proc/process_cyberman_hacking()
 	for(var/obj/effect/cyberman_hack/H in active_cybermen_hacks)
 		if(!H || qdeleted(H))
 			active_cybermen_hacks -= H
 	#ifdef CYBERMEN_DEBUG
-	world << "---------Active Hacks:-----------"
-	for(var/obj/effect/cyberman_hack/H in active_cybermen_hacks)
-		world << "\t[H.target_name]"
+	if(active_cybermen_hacks && active_cybermen_hacks.len)
+		world << "---------Active Hacks:-----------"
+		for(var/obj/effect/cyberman_hack/H in active_cybermen_hacks)
+			world << "\t[H.target_name]"
 	#endif
 	for(var/datum/mind/cyberman in cybermen)
 		if(!cyberman || qdeleted(cyberman))
@@ -104,6 +247,7 @@
 		if(cyberman.cyberman.emp_hit > 0)
 			cyberman.cyberman.emp_hit--
 
+/datum/cyberman_network/proc/process_cyberman_objectives()
 	for(var/datum/mind/cyberman in cybermen)
 		cyberman.cyberman.process_hacking(cyberman.current)
 	for(var/obj/effect/cyberman_hack/H in active_cybermen_hacks)
@@ -129,11 +273,11 @@
 		generate_cybermen_objective(cybermen_objectives.len+1)
 		display_current_cybermen_objective()
 
-/datum/game_mode/proc/generate_cybermen_objective(phase_num)
-	var/list/datum/objective/cybermen/explore_objectives = list(new /datum/objective/cybermen/explore/get_research_levels(), new /datum/objective/cybermen/explore/get_secret_documents(), new /datum/objective/cybermen/explore/get_access())
-	var/list/datum/objective/cybermen/expand_objectives = list(new /datum/objective/cybermen/expand/convert_crewmembers(), new /datum/objective/cybermen/expand/hack_ai(), new /datum/objective/cybermen/expand/convert_heads())
-	var/list/datum/objective/cybermen/exploit_objectives = list(new /datum/objective/cybermen/exploit/analyze_and_hack())
-	var/list/datum/objective/cybermen/exterminate_objectives = list(new /datum/objective/cybermen/exterminate/nuke_station(), new /datum/objective/cybermen/exterminate/hijack_shuttle(), new /datum/objective/cybermen/exterminate/eliminate_humans())
+/datum/cyberman_network/proc/generate_cybermen_objective(phase_num)
+	var/list/datum/objective/cybermen/explore_objectives = list(/datum/objective/cybermen/explore/get_research_levels, /datum/objective/cybermen/explore/get_secret_documents, /datum/objective/cybermen/explore/get_access)
+	var/list/datum/objective/cybermen/expand_objectives = list(/datum/objective/cybermen/expand/convert_crewmembers, /datum/objective/cybermen/expand/hack_ai, /datum/objective/cybermen/expand/convert_heads)
+	var/list/datum/objective/cybermen/exploit_objectives = list(/datum/objective/cybermen/exploit/analyze_and_hack)
+	var/list/datum/objective/cybermen/exterminate_objectives = list(/datum/objective/cybermen/exterminate/nuke_station, /datum/objective/cybermen/exterminate/hijack_shuttle, /datum/objective/cybermen/exterminate/eliminate_humans)
 
 	var/datum/objective/cybermen/current_objective
 	switch(phase_num)
@@ -159,17 +303,18 @@
 		log_game("ERROR: unable to select a valid cybermen objective from phase [phase_num] pool. Taking an objective from the next stage pool instead.")
 		generate_cybermen_objective(phase_num+1)//this will make the cybermen have two later phase objectives for the round instead.
 
-/datum/game_mode/proc/generate_cybermen_objective_helper(list/datum/objective/cybermen/possible_objectives)
+/datum/cyberman_network/proc/generate_cybermen_objective_helper(list/datum/objective/cybermen/possible_objectives)
 	var/datum/objective/cybermen/current_objective = null
 	while(!current_objective && possible_objectives.len > 0)
-		current_objective = pick(possible_objectives)
+		var/type = pick(possible_objectives)
+		current_objective = new type()
 		if(!current_objective.is_valid() && !current_objective.make_valid() )
 			possible_objectives -= current_objective
 			current_objective = null
 	return current_objective
 
 
-/datum/game_mode/proc/display_all_cybermen_objectives(datum/mind/M)
+/datum/cyberman_network/proc/display_all_cybermen_objectives(datum/mind/M)
 	if(cybermen_objectives.len < 1)
 		M.current << "<span class='notice'>No objectives to display.</span>"
 		return
@@ -187,7 +332,7 @@
 	M.current << "[O.explanation_text]"
 	M.current << (O.check_completion() ? "<font color='green'><b>Complete</b></font><br>" : "<font color='yellow'><b>In Progress</b></font>")
 
-/datum/game_mode/proc/display_current_cybermen_objective()
+/datum/cyberman_network/proc/display_current_cybermen_objective()
 	if(cybermen_objectives.len > 0)
 		var/datum/objective/cybermen/O = cybermen_objectives[cybermen_objectives.len]
 		O.check_completion()//needed for updating explanation text.
@@ -196,122 +341,9 @@
 	else
 		log_game("ERROR - [usr] attempted to display current cyberman objective when there are no objectives")
 
-/datum/game_mode/proc/message_all_cybermen(message)
+/datum/cyberman_network/proc/message_all_cybermen(message)
 	for(var/datum/mind/cyberman in cybermen)
 		cyberman.current << message
-
-/*
-/datum/game_mode/proc/is_cyberman(datum/mind/mind)//fast and simple one
-	return mind && mind.cyberman && (mind in cybermen)
-*/
-
-/datum/game_mode/proc/is_cyberman(datum/mind/mind)//better for logging errors
-	if(!mind)
-		return 0
-	var/in_cybermen = (mind in cybermen)
-	if((mind.cyberman && !in_cybermen) || (!mind.cyberman && in_cybermen))
-		var/message = mind.cyberman ? "[mind] was found to have an initialized cyberman datum, but is not a registered cyberman. Please report this bug to a coder." : "[mind] was found to not have an initialized cyberman datum, but is a registered cyberman. Please report this bug to a coder."
-		log_game(message)
-		return 0
-	return mind.cyberman
-
-/datum/game_mode/proc/add_cyberman(var/datum/mind/cyberman, var/message_override)
-	if(is_cyberman(cyberman))
-		return
-	cybermen += cyberman//careful this doesn't happen twice.
-	cyberman.cyberman = new /datum/cyberman_datum()
-	cyberman.special_role = "cyberman"
-	cyberman.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Became a cyberman</span>"
-
-	update_cybermen_icons_add(cyberman)
-	if(message_override)
-		cyberman.current << message_override
-	else
-		cyberman.current << "<span class='boldannounce'><b><font size=3>You are now a Cyberman! Work with your fellow cybermen and do not harm them.</font></b></span>"
-
-	var/mob/living/carbon/human/H = cyberman.current
-	if(cyberman.assigned_role == "Clown")
-		H << "<span class='notice'>Your superior Cyberman form has allowed you to overcome your clownish genetics.</span>"
-		H.dna.remove_mutation(CLOWNMUT)
-	if(isloyal(H))
-		H << "<span class='notice'>Your loyalty implant has been deactivated, but not destroyed. While scanners will show that it is still active, you are no longer loyal to Nanotrasen.</span>"//I personnally am not a fan of this, but Alblaka said it so that's what I've done.
-
-	cyberman.current << "<span class='notice'>As a Cyberman, hacking is your most valuable ability. Click on \'Prepare Hacking\' in the Cybermen tab to use it.</span>"
-	cyberman.current << "<span class='notice'>You can use the Cyberman Broadcast to undetectably communicate with your fellow Cybermen. You can also use robot talk with .b, but this will alert any unhacked cyborgs or AIs to your presence.</span>"
-	cyberman.current << "<span class='notice'>\n\"Cybermen\" is an experimental gamemode. If you find any bugs, please submit an issue on the server's github. If a bug prevents you from completing an objective, or you are not properly assigned an objective, contact an admin via ahelp.</span>"
-	display_all_cybermen_objectives(cyberman)
-
-/datum/game_mode/proc/remove_cyberman(datum/mind/cyberman, var/message_override)
-	if(!is_cyberman(cyberman) )
-		return
-	//drop all installed parts (except limbs)
-	for(var/obj/item/weapon/stock_parts/capacitor/P in cyberman.cyberman.upgrades_installed)
-		P.loc = cyberman.current.loc
-		cyberman.cyberman.upgrades_installed -= P
-	qdel(cyberman.cyberman)
-	cyberman.cyberman = null//redundant but doesn't hurt to be safe.
-	cybermen -= cyberman
-	cyberman.current.attack_log += "\[[time_stamp()]\] <span class='danger'>No longer a cyberman</span>"
-	cyberman.special_role = null
-
-	update_cybermen_icons_remove(cyberman)
-	var/mob/living/carbon/human/H = cyberman.current
-	if(issilicon(H))
-		H.audible_message("<span class='notice'>[H] lets out a short blip.</span>", "<span class='userdanger'>You have been turned into a robot! You are no longer a cyberman! Though you try, you cannot remember anything about the cybermen or your time as one...</span>")
-	else
-		H.visible_message("<span class='big'>[H] looks like their mind is their own again!</span>", message_override ? message_override : "<span class='userdanger'>Your mind is your own again! You are no longer a cyberman! Though you try, you cannot remember anything about the cybermen or your time as one...</span>")
-		if(isloyal(H))
-			H << "<span class='notice'>Your loyalty implant has been re-activated - you are once again unfailingly loyal to Nanotrasen.</span>"
-
-/datum/game_mode/cybermen/check_finished()
-	return ..() || cybermen_win
-
-/datum/game_mode/cybermen/check_win()
-	return cybermen_win
-
-/datum/game_mode/cybermen/declare_completion()
-	..()
-	if(!cybermen_win && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
-		world << "<span class='redtext'>The Cybermen failed to take control of the station!</span>"
-	else if(cybermen_win && station_was_nuked)
-		world << "<span class='greentext'>The Cybermen win! They acivated the station's self-destruct device!</span>"
-	else if(cybermen_win)
-		world << "<span class='greentext'>The Cybermen win! They have exterminated or stranded all of the non-cybermen!</span>"
-	else
-		world << "<span class='redtext'>The Cybermen have failed!</span>"
-
-	world << "<br><span class='big'><b>The Cybermens' Objectives were:</b></span>"
-	var/datum/objective/cybermen/O
-	for(var/i = 1 to cybermen_objectives.len-1)
-		O = cybermen_objectives[i]
-		if(O)
-			world << "Phase [i]:[O.phase]"
-			world << "[O.explanation_text]"
-			world << "<font color='green'><b>Completed</b></font><br>"
-	O = cybermen_objectives[cybermen_objectives.len]
-	world << "Phase [cybermen_objectives.len]:[O.phase]"
-	world << "[O.explanation_text]"
-	world << (O.check_completion() ? "<font color='green'><b>Completed</b></font><br>" : "<font color='red'><b>Failed</b></font>")
-	return 1
-
-/datum/game_mode/proc/auto_declare_completion_cybermen()
-	if(cybermen.len > 0)
-		var/text = ""
-		text += "<br><span class='big'><b>The Cybermen were:</b></span>"
-		for(var/datum/mind/cyberman in ticker.mode.cybermen)
-			text += printplayer(cyberman)
-		world << text
-
-datum/game_mode/proc/update_cybermen_icons_add(datum/mind/cyberman)
-	var/datum/atom_hud/antag/cyberman_hud = huds[ANTAG_HUD_CYBERMEN]
-	cyberman_hud.join_hud(cyberman.current)
-	set_antag_hud(cyberman.current, "cybermen")
-
-datum/game_mode/proc/update_cybermen_icons_remove(datum/mind/cyberman)
-	var/datum/atom_hud/antag/cyberman_hud = huds[ANTAG_HUD_CYBERMEN]
-	cyberman_hud.leave_hud(cyberman.current)
-	set_antag_hud(cyberman.current, null)
-
 
 ////////////////////////////////////////////////////////
 //CYBERMAN DATUM
@@ -364,12 +396,13 @@ datum/game_mode/proc/update_cybermen_icons_remove(datum/mind/cyberman)
 	else if(get_dist(usr, target) > hack_max_start_dist)
 		usr << "<span class='warning'>You are to far away to hack \the [target].</span>"
 	else
-		usr.audible_message("<span class='notice'>You hear a faint sound of static.</span>", CYBERMEN_HACK_NOISE_DIST )
-		if(istype(target, /mob/living/carbon/human))
-			var/mob/living/carbon/human/H = target
-			H << "<span class='warning'>You feel a tiny prick!</span>"
 		var/obj/effect/cyberman_hack/newHack = target.get_cybermen_hack()
 		if(newHack)
+			usr.audible_message("<span class='notice'>You hear a faint sound of static.</span>", CYBERMEN_HACK_NOISE_DIST )
+			if(istype(target, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = target
+				H << "<span class='warning'>You feel a tiny prick!</span>"
+			cyberman_network.message_all_cybermen("<span class='notice>[newHack.display_verb] of [newHack.target_name] started by [usr].</span>")
 			newHack.start()
 		else
 			usr << "<span class='warning'>\The [target] cannot be hacked.</span>"
@@ -379,7 +412,7 @@ datum/game_mode/proc/update_cybermen_icons_remove(datum/mind/cyberman)
 	if(!validate(user) || !hack)
 		return
 	if(hack.can_cancel(user) )
-		hack.drop("<span class='notice'>[hack.display_verb] of \the [hack.target_name] canceled by [user].<span>")
+		hack.drop("<span class='warning'>[hack.display_verb] of \the [hack.target_name] canceled by [user].<span>")
 	else
 		user << "<span class='warning'>You cannot cancel a hack unless you are close enough to maintain it!</span>"
 
@@ -439,14 +472,14 @@ datum/game_mode/proc/update_cybermen_icons_remove(datum/mind/cyberman)
 		return
 	if(user.stat || user.stunned || emp_hit)
 		return
-	if(ticker.mode.active_cybermen_hacks.len == 0)
+	if(cyberman_network.active_cybermen_hacks.len == 0)
 		return
 	update_processing_power(user)
-	if(manual_selected_hack && (manual_selected_hack in ticker.mode.active_cybermen_hacks) )
+	if(manual_selected_hack && (manual_selected_hack in cyberman_network.active_cybermen_hacks) )
 		selected_hack = manual_selected_hack
-	else if(ticker.mode.active_cybermen_hacks.len > 0)
+	else if(cyberman_network.active_cybermen_hacks.len > 0)
 		var/best_preference = -1
-		for(var/obj/effect/cyberman_hack/current_hack in ticker.mode.active_cybermen_hacks)
+		for(var/obj/effect/cyberman_hack/current_hack in cyberman_network.active_cybermen_hacks)
 			var/this_preference = current_hack.get_preference_for(user)
 			if(this_preference > best_preference)
 				best_preference = this_preference

--- a/code/game/gamemodes/cybermen/cybermen_abilities.dm
+++ b/code/game/gamemodes/cybermen/cybermen_abilities.dm
@@ -1,22 +1,11 @@
+#define CYBERMEN_HACK_NOISE_DIST 3
+
+//////////////////////
+//Ability Activators//
+//////////////////////
 
 /obj/effect/proc_holder/cyberman
 	panel = "Cyberman"
-
-/obj/effect/proc_holder/cyberman/proc/get_user_selected_hack(var/mob/living/carbon/human/user = usr, var/null_option)
-	var/list/hacks = list()
-	for(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)
-		hacks += hack.target_name
-	if(null_option)
-		hacks += null_option
-	var/target_hack_name = input(usr, "Choose which hack you wish to contribute to:", "Cyberman Hack Management") as anything in hacks
-	if(!target_hack_name || target_hack_name == null_option)
-		return null
-	var/obj/effect/cyberman_hack/target_hack = null
-	for(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)//this will have issues if two different hacked objects have the same name.
-		if(hack.target_name == target_hack_name)
-			target_hack = hack
-			break
-	return target_hack
 
 /obj/effect/proc_holder/cyberman/commune
 	name = "Cyberman Broadcast"
@@ -26,66 +15,56 @@
 	if(!(usr.mind && usr.mind.cyberman))
 		usr << "You are not a cyberman, you should not be able to do this!"
 		return 0
-	if(!usr.mind.cyberman.emp_hit)
-		var/input = stripped_input(usr, "Enter a message to share with all other Cybermen.", "Cybermen Broadcast", "")
-		if(input)
-			cyberman_network.log_broadcast("[usr] Sent a Cyberman Broadcast: [input]")
-			for(var/datum/mind/cyberman in cyberman_network.cybermen)
-				var/distorted_message = input
-				if(cyberman.cyberman.emp_hit)
-					distorted_message = Gibberish2(input, cyberman.cyberman.emp_hit*1.6)
-				cyberman.current << "<span class='cyberman'>Cyberman Broadcast: [distorted_message]</span>"
-			for(var/mob/dead in dead_mob_list)
-				dead << "<span class='cyberman'>Cyberman Broadcast: [input]</span>"
-		return 1
-	else
-		usr << "<span class='notice'>You were hit by an EMP recently, you cannot use the cyberman broadcast!</span>"
-		return 0
+	return usr.mind.cyberman.use_broadcast(usr)
 
 /mob/living/proc/cyberman_hack(var/atom/target in world)//for the context menu option. Disabled for now becuase middle-click works just fine..
 	//set category = ""//automatically goes in "Commands" tab.
 	set name = "Hack"
-	usr.mind.cyberman.initiate_hack(target)
+	usr.mind.cyberman.initiate_hack(target, usr)
 
 /obj/effect/proc_holder/cyberman/cyberman_toggle_quickhack
 	name = "Prepare Hacking"
 	desc = "Enable or disable your cyberman hacking module."
 
 /obj/effect/proc_holder/cyberman/cyberman_toggle_quickhack/Click()
-	if(usr.mind.cyberman)
-		usr.mind.cyberman.quickhack = !usr.mind.cyberman.quickhack
-		usr << (usr.mind.cyberman.quickhack ? "You prepare to hack nearby objects. Use alt- or middle-click to hack." : "You decide not to hack anything for the moment.")
+	if(!usr.mind || !usr.mind.cyberman)
+		return
+	usr.mind.cyberman.toggle_quickhack(usr)
 
 /obj/effect/proc_holder/cyberman/cyberman_manual_select_hack
 	name = "Select Current Hack"
 	desc = "Select the hack you are contributing processing power to."
 
 /obj/effect/proc_holder/cyberman/cyberman_manual_select_hack/Click()
-	if(!usr || !usr.mind || !usr.mind.cyberman)
+	if(!usr.mind || !usr.mind.cyberman)
 		return
-	var/obj/effect/cyberman_hack/selected_hack = get_user_selected_hack(usr, "(automatic)")
-	usr.mind.cyberman.select_hack(usr, selected_hack)
+	usr.mind.cyberman.manual_select_hack(usr)
 
 /obj/effect/proc_holder/cyberman/cyberman_cancel_hack//maybe this should open an "are you sure?" dialogue.
 	name = "Cancel Hack"
 	desc = "End a hack prematurely."
 
 /obj/effect/proc_holder/cyberman/cyberman_cancel_hack/Click()
-	if(!usr || !usr.mind || !usr.mind.cyberman)
+	if(!usr.mind || !usr.mind.cyberman)
 		return
-	var/obj/effect/cyberman_hack/selected_hack = get_user_selected_hack(usr, "(none)")
-	usr.mind.cyberman.cancel_hack(usr, selected_hack)
-
+	usr.mind.cyberman.manual_cancel_hack()
+/*
 /obj/effect/proc_holder/cyberman/cyberman_cancel_component_hack
 	name = "Cancel Component Hack"//needs a new name
 	desc = "End the closest component hack of a multiple-vector hack."
 
 /obj/effect/proc_holder/cyberman/cyberman_cancel_component_hack/Click()
-	if(!usr || !usr.mind || !usr.mind.cyberman)
+	if(!usr.mind || !usr.mind.cyberman)
 		return
-	var/obj/effect/cyberman_hack/selected_hack = get_user_selected_hack(usr, "(none)")
-	usr.mind.cyberman.cancel_closest_component_hack(usr, selected_hack)
+	usr.mind.cyberman.manual_cancel_component_hack(usr)
 
+/mob/living/carbon/human/proc/cancel_hack_context(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)
+	set name = "Cancel Hack"
+	set category = "Hacking"
+	if(!usr.mind || !usr.mind.cyberman)
+		return
+	usr.mind.cyberman.cancel_hack(usr, hack)
+*/
 /obj/effect/proc_holder/cyberman/cyberman_disp_objectives
 	name = "Display Objectives"
 	desc = "Display all cyberman objectives that have been assigned so far."
@@ -93,6 +72,123 @@
 /obj/effect/proc_holder/cyberman/cyberman_disp_objectives/Click()
 	cyberman_network.display_all_cybermen_objectives(usr.mind)
 
+////////////////////
+//Actual abilities//
+////////////////////
+/datum/cyberman_datum/proc/initiate_hack(var/atom/target, var/mob/living/carbon/human/user = usr)
+	if(user.stat)//no more hacking while a ghost
+		return
+	if(!validate(user) )
+		user << "<span class='warning'>You are not a Cyberman, you cannot initiate a hack.</span>"
+		return
+	if(emp_hit)
+		user << "<span class='warning'>You were recently hit by an EMP, you cannot hack right now!</span>"
+		return
+	if(get_dist(user, target) > hack_max_start_dist)
+		user << "<span class='warning'>You are to far away to hack \the [target].</span>"
+		return
+	var/obj/effect/cyberman_hack/newHack = target.get_cybermen_hack()
+	if(newHack)
+		user.audible_message("<span class='danger'>You hear a faint sound of static.</span>", CYBERMEN_HACK_NOISE_DIST )
+		if(istype(target, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = target
+			H << "<span class='warning'>You feel a tiny prick!</span>"
+		cyberman_network.message_all_cybermen("<span class='notice>[newHack.display_verb] of [newHack.target_name] started by [user].</span>")
+		newHack.start()
+	else
+		user << "<span class='warning'>\The [target] cannot be hacked.</span>"
+
+
+/datum/cyberman_datum/proc/cancel_hack(var/mob/living/carbon/human/user = usr, var/obj/effect/cyberman_hack/hack)
+	if(!validate(user) || !hack || user.stat || user.stunned)
+		user << "<span class='warning'>You can't do that right now!</span>"
+		return
+	if(hack.can_cancel(user) )
+		hack.drop("<span class='warning'>[hack.display_verb] of \the [hack.target_name] canceled by [user].<span>")
+	else
+		user << "<span class='warning'>You cannot cancel a hack unless you are close enough to maintain it!</span>"
+
+
+/datum/cyberman_datum/proc/cancel_closest_component_hack(var/mob/living/carbon/human/user = usr, var/obj/effect/cyberman_hack/multiple_vector/hack)
+	if(!validate(user) || !hack || !istype(hack, /obj/effect/cyberman_hack/multiple_vector))
+		return
+	hack.do_tick_calculations_if_required(user)
+	if(!hack.tick_best_hack)
+		user << "<span class='warning'>Error: No component hacks of [hack.target_name] detected.</span>"
+		return
+	if(!hack.tick_best_hack.can_cancel(user) )
+		user << "<span class='warning'>You are not close enough to cancel the [hack.tick_best_hack.display_verb] of \the [hack.tick_best_hack.target_name], the closest component hack of \the [hack.target_name].</span>"
+		return
+	if(hack.component_hacks.len == 1 && !hack.innate_processing)//safeguard in case they don't realise that they are the last one hacking the ai/tcomms network/etc. If it is a magic admin/debug hack, though, you can always stop contributing.
+		user << "<span class='warning'>The [hack.tick_best_hack.display_verb] of \the [hack.tick_best_hack.target_name] is the only remaining component hack of \the [hack.target_name]. If you want to cancel it, you must cancel the whole hack.</span>"
+		return
+	hack.tick_best_hack.drop("<span class='notice'>The [hack.tick_best_hack.display_verb] of \the [hack.tick_best_hack.target_name], which was contributing to the [hack.display_verb] of \the [hack.target_name], was canceled by [user].<span>")
+
+
+/datum/cyberman_datum/proc/select_hack(var/mob/living/carbon/human/user = usr, var/obj/effect/cyberman_hack/hack)
+	if(!validate(user))
+		return
+	if(hack == user.mind.cyberman.manual_selected_hack)
+		user.mind.cyberman.manual_selected_hack = null
+	else
+		user.mind.cyberman.manual_selected_hack = hack
+
+/datum/cyberman_datum/proc/use_broadcast(var/mob/living/carbon/human/user = usr)
+	if(user.stat == DEAD || user.stat == UNCONSCIOUS)//you can still use it while stunned.
+		user << "<span class='warning'>You can't use that right now!</span>"
+		return 0
+	if(emp_hit)
+		user << "<span class='warning'>You were hit by an EMP recently, you cannot use the cyberman broadcast!</span>"
+		return 0
+	var/input = stripped_input(user, "Enter a message to share with all other Cybermen.", "Cybermen Broadcast", "")
+	if(input)
+		cyberman_network.log_broadcast("[user]([user.ckey ? user.ckey : "No ckey"]) Sent a Cyberman Broadcast: [input]")
+		for(var/datum/mind/cyberman in cyberman_network.cybermen)
+			var/distorted_message = input
+			if(cyberman.cyberman.emp_hit)
+				distorted_message = Gibberish2(input, cyberman.cyberman.emp_hit*1.6)
+			cyberman.current << "<span class='cyberman'>Cyberman Broadcast: [distorted_message]</span>"
+		for(var/mob/dead in dead_mob_list)
+			dead << "<span class='cyberman'>Cyberman Broadcast: [input]</span>"
+	return 1
+
+/datum/cyberman_datum/proc/get_user_selected_hack(var/mob/living/carbon/human/user = usr, var/display, var/null_option)
+	var/list/hacks = list()
+	for(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)
+		hacks += hack.target_name
+	if(null_option)
+		hacks += null_option
+	var/target_hack_name = input(usr, display, "Cyberman Hack Management") as null|anything in hacks
+	if(!target_hack_name || target_hack_name == null_option)
+		return null
+	var/obj/effect/cyberman_hack/target_hack = null
+	for(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)//this will have issues if two different hacked objects have the same name.
+		if(hack.target_name == target_hack_name)
+			target_hack = hack
+			break
+	return target_hack
+
+/datum/cyberman_datum/proc/toggle_quickhack(var/mob/living/carbon/human/user = usr)
+	quickhack = !quickhack
+	user << (user.mind.cyberman.quickhack ? "You prepare to hack nearby objects. Use alt- or middle-click to hack." : "You decide not to hack anything for the moment.")
+
+
+/datum/cyberman_datum/proc/manual_select_hack(var/mob/living/carbon/human/user = usr)
+	var/obj/effect/cyberman_hack/selected_hack = get_user_selected_hack(user, "Choose which hack you wish to contribute to:", "(automatic)")
+	if(selected_hack)
+		select_hack(user, selected_hack)
+
+
+/datum/cyberman_datum/proc/manual_cancel_hack(var/mob/living/carbon/human/user = usr)
+	var/obj/effect/cyberman_hack/selected_hack = get_user_selected_hack(user, "Choose which hack you wish to contribute to:", "(none)")
+	if(selected_hack)
+		user.mind.cyberman.cancel_hack(user, selected_hack)
+
+
+/datum/cyberman_datum/proc/manual_cancel_component_hack(var/mob/living/carbon/human/user = usr)
+	var/obj/effect/cyberman_hack/selected_hack = get_user_selected_hack(user, "(none)")
+	if(selected_hack)
+		user.mind.cyberman.cancel_closest_component_hack(usr, selected_hack)
 
 /////////////////////////////////////////////
 ///////////////DEBUG/ADMIN///////////////////

--- a/code/game/gamemodes/cybermen/cybermen_hacking.dm
+++ b/code/game/gamemodes/cybermen/cybermen_hacking.dm
@@ -9,7 +9,7 @@
 #define CYBERMEN_HACK_ID_CARD_COST 100
 #define CYBERMEN_HACK_ANALYZE_COST 100
 #define CYBERMEN_HACK_BUTTON_COST 200
-#define CYBERMEN_HACK_RND_SERVER_COST 500
+#define CYBERMEN_HACK_RND_SERVER_COST 300
 #define CYBERMEN_HACK_TECH_DISK_COST 100
 #define CYBERMEN_HACK_COMMS_CONSOLE_COST 400
 #define CYBERMEN_HACK_NUKE_COST 1000
@@ -162,6 +162,7 @@
 	var/tick_same_z_level
 
 /obj/effect/cyberman_hack/New(var/atom/target, var/mob/living/carbon/human/user = usr)
+	name = "[display_verb] of \the [target_name]"
 	if(!cyberman_network)
 		new /datum/cyberman_network()
 	src.target = target
@@ -457,7 +458,8 @@
 	return ..()
 
 //procs and verbs for managing hacks in the stat panel through the context menu.
-/obj/effect/cyberman_hack/verb/cancel()
+/*
+/obj/effect/cyberman_hack/verb/cancel(/obj/effect/)
 	set src in world
 	set name = "Cancel Hack"
 	if(usr && usr.mind && usr.mind.cyberman)
@@ -474,9 +476,11 @@
 	set name = "Contribute to Hack"
 	if(usr && usr.mind && usr.mind.cyberman)
 		usr.mind.cyberman.select_hack(usr, src)
-
+*/
 /obj/effect/cyberman_hack/DblClick()
-	select()
+	if(!usr.mind || !usr.mind.cyberman)
+		return
+	usr.mind.cyberman.select_hack(usr, src)
 
 //add control_click to cancel?
 
@@ -493,6 +497,7 @@
 /obj/effect/cyberman_hack/machinery/airlock/New()
 	..()
 	target_name += " airlock"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/machinery/airlock/start_helper()
 	if(!..() )
@@ -532,6 +537,7 @@
 /obj/effect/cyberman_hack/machinery/windoor/New()
 	..()
 	target_name += " windoor"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/machinery/windoor/start_helper()
 	if(!..() )
@@ -645,6 +651,7 @@
 /obj/effect/cyberman_hack/cyborg/New()
 	..()
 	target_name += " (Cyborg)"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/cyborg/start_helper()
 	if(!..())
@@ -715,6 +722,7 @@
 /obj/effect/cyberman_hack/multiple_vector/ai/New()
 	..()
 	target_name += " (AI)"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/multiple_vector/ai/start_helper()
 	if(!..())
@@ -802,7 +810,8 @@
 	required_type = /obj/machinery/computer/upload/ai/
 
 /obj/effect/cyberman_hack/machinery/ai_upload/start()
-	return component_hack_start(/obj/effect/cyberman_hack/multiple_vector/ai/, target)
+	var/obj/machinery/computer/upload/ai/the_upload = target
+	return component_hack_start(/obj/effect/cyberman_hack/multiple_vector/ai/, the_upload.current)
 
 ////////////////////////////////////////////////////////
 //ANALYZE OBJECT
@@ -847,6 +856,7 @@
 /obj/effect/cyberman_hack/machinery/button/New()
 	..()
 	target_name += " button"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/machinery/button/complete()
 	var/obj/machinery/button/B = target
@@ -960,6 +970,8 @@
 	..()
 	var/mob/living/carbon/human/H = target
 	cost = 200 + 400*cyberman_network.cybermen.len//you can just convert a bunch of people at once to keep the cost down. Possible expoit, but won't worry about it now.
+	if(istype(cyberman_network.cybermen_objectives[cyberman_network.cybermen_objectives.len], /datum/objective/cybermen/exterminate/eliminate_humans/))//discourages murderboning. Hopefully.
+		cost = min(cost, 3000)
 	if(isloyal(H))
 		cost = cost*2
 	for(var/obj/item/organ/limb/L in H.organs)
@@ -977,6 +989,9 @@
 	else if(!H.mind || !H.key || !H.client)
 		drop("<span class='warning'>[display_verb] of [target_name] failed, \he is catatonic.</span>")
 		return 0
+	else if(H.stat == DEAD)
+		drop("<span class='warning'>[display_verb] of [target_name] failed, \he is dead.</span>")
+		return 0
 	hallucination = new /obj/effect/hallucination/cybermen_conversion(H.loc, H)
 	return 1
 
@@ -988,6 +1003,8 @@
 	if(ticker.mode.is_cyberman(H.mind))
 		drop("<span class='warning'>[target_name] has become cyberman through other means, [display_verb] canceled.</span>")
 		return
+	if(H.stat == DEAD)
+		drop("<span class='warning'>[display_verb] of [target_name] failed, \he is dead.</span>")
 	if(!hallucination)
 		hallucination = new /obj/effect/hallucination/cybermen_conversion(H.loc, H)
 	hallucination.percent_complete = (progress/cost)*100
@@ -1168,6 +1185,7 @@
 /obj/effect/cyberman_hack/barsign/New()
 	..()
 	target_name = "bar sign"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/barsign/start_helper()
 	if(!..())
@@ -1228,6 +1246,7 @@
 /obj/effect/cyberman_hack/machinery/vending_machine/New()
 	..()
 	target_name += " vendor"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/machinery/vending_machine/complete()
 	var/obj/machinery/vending/T = target
@@ -1289,6 +1308,7 @@
 /obj/effect/cyberman_hack/multiple_vector/telecomms/New()
 	..()
 	target_name = "telecomms network"
+	name = "[display_verb] of \the [target_name]"
 
 /obj/effect/cyberman_hack/multiple_vector/telecomms/start_helper()
 	if(!..())

--- a/code/game/gamemodes/cybermen/cybermen_objectives.dm
+++ b/code/game/gamemodes/cybermen/cybermen_objectives.dm
@@ -1,4 +1,4 @@
-/datum/game_mode
+/datum/cyberman_network
 	var/list/cybermen_analyze_targets = list(/obj/item/weapon/gun/energy/laser/captain = "the captain's antique laser gun", //stolen from objective_items.dm. Could just use the objective datums instead.
 								/obj/item/weapon/gun/energy/gun/hos = "the head of security's personal laser gun",
 								/obj/item/weapon/hand_tele = "a hand teleporter",
@@ -52,7 +52,7 @@
 	if(..())
 		return 1
 	var/current_amount = 0
-	for(var/datum/tech/current_data in ticker.mode.cybermen_research_downloaded)
+	for(var/datum/tech/current_data in cyberman_network.cybermen_research_downloaded)
 		if(current_data.level)
 			current_amount += (current_data.level-1)//can't let that level 1 junk give us points
 	return current_amount >= target_research_levels
@@ -64,7 +64,7 @@
 /datum/objective/cybermen/explore/get_secret_documents/check_completion()
 	if(..())
 		return 1
-	for(var/obj/item/documents/nanotrasen/D in ticker.mode.cybermen_hacked_objects)
+	for(var/obj/item/documents/nanotrasen/D in cyberman_network.cybermen_hacked_objects)
 		return 1
 	return 0
 
@@ -75,7 +75,7 @@
 /datum/objective/cybermen/explore/get_access/check_completion()
 	if(..())
 		return 1
-	return (access_captain in ticker.mode.cybermen_access_downloaded)
+	return (access_captain in cyberman_network.cybermen_access_downloaded)
 
 //////////////////////////////
 //////////EXPAND//////////////
@@ -106,7 +106,7 @@
 			humans_on_station++
 	if(humans_on_station > 3)//needs a somewhat sane lozer limit
 		target_cybermen_num = humans_on_station
-		ticker.mode.message_all_cybermen("<span class='notice'>Too few humans detected aboard the station. Number of required cybermen reduced to [target_cybermen_num].</span>")
+		cyberman_network.message_all_cybermen("<span class='notice'>Too few humans detected aboard the station. Number of required cybermen reduced to [target_cybermen_num].</span>")
 		explanation_text = "Convert crewmembers until there are [target_cybermen_num] living cybermen on the station."
 		return 1
 	else
@@ -116,7 +116,7 @@
 	if(..())
 		return 1
 	var/living_cybermen = 0
-	for(var/datum/mind/M in ticker.mode.cybermen)
+	for(var/datum/mind/M in cyberman_network.cybermen)
 		if(M.current && !(M.current.stat | DEAD))
 			living_cybermen++
 	return living_cybermen >= target_cybermen_num
@@ -141,14 +141,14 @@
 		if(targetAI && targetAI.current != null && !qdeleted(targetAI.current) && targetAI.key && targetAI.client)
 			targetAI = new_ai
 			explanation_text = "Hack [targetAI.current.name], the AI."
-			ticker.mode.message_all_cybermen("Cybermen AI hack target changed. New AI hack target is [targetAI.current.name].")
+			cyberman_network.message_all_cybermen("Cybermen AI hack target changed. New AI hack target is [targetAI.current.name].")
 			return 1
 	return 0
 
 /datum/objective/cybermen/expand/hack_ai/check_completion()
 	if(..())
 		return 1
-	return targetAI in ticker.mode.cybermen_hacked_objects
+	return targetAI in cyberman_network.cybermen_hacked_objects
 
 //CONVERT HEADS
 /datum/objective/cybermen/expand/convert_heads
@@ -170,7 +170,7 @@
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
 		if(rank in command_positions)
-			for(var/datum/mind/M in ticker.mode.cybermen)
+			for(var/datum/mind/M in cyberman_network.cybermen)
 				if(M.current.real_name == name)//possible issues with duplicate names
 					num++
 					break
@@ -192,8 +192,8 @@
 
 /datum/objective/cybermen/exploit/analyze_and_hack/New()
 	..()
-	var/list/analyze_target_candidates = ticker.mode.cybermen_analyze_targets.Copy()
-	var/list/hack_target_candidates = ticker.mode.cybermen_hack_targets.Copy()
+	var/list/analyze_target_candidates = cyberman_network.cybermen_analyze_targets.Copy()
+	var/list/hack_target_candidates = cyberman_network.cybermen_hack_targets.Copy()
 	var/remaining = num_analyze_targets
 	while(remaining)
 		var/candidate = pick(analyze_target_candidates)
@@ -227,7 +227,7 @@
 	var/list/done_indicators = list()
 	for(var/current2 in targets_copy)
 		var/done_indicator = "(<font color='red'>Not Completed</font>)"
-		for(var/current in ticker.mode.cybermen_hacked_objects)
+		for(var/current in cyberman_network.cybermen_hacked_objects)
 			if(istype(current, current2))
 				targets_copy -= current2
 				done_indicator = "(<font color='green'>Completed</font>)"
@@ -281,7 +281,7 @@
 
 /datum/objective/cybermen/exterminate/hijack_shuttle/New()
 	..()
-	required_escaped_cybermen = min(6, ticker.mode.cybermen.len)
+	required_escaped_cybermen = min(6, cyberman_network.cybermen.len)
 	explanation_text = "Hijack the escape shuttle, ensuring that no non-cybermen escape on it. At least [required_escaped_cybermen] Cybermen must escape on the shuttle. The escape pods may be ignored."
 
 /datum/objective/cybermen/exterminate/hijack_shuttle/check_completion()//some copy-pasting from objective.dm
@@ -319,4 +319,4 @@
 				cybermen_num++
 			else
 				non_cybermen_num++
-	return (cybermen_num / (cybermen_num + non_cybermen_num))*100 >= target_percent
+	return (cybermen_num + non_cybermen_num > 0) && (cybermen_num / (cybermen_num + non_cybermen_num))*100 >= target_percent

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -126,7 +126,7 @@ MASS SPECTROMETER
 		var/mob/living/carbon/human/H = M
 		if(H.heart_attack)
 			user << "<span class='danger'>Subject suffering from heart attack: Apply defibrillator immediately!</span>"
-		for(var/obj/effect/cyberman_hack/human/hack in ticker.mode.active_cybermen_hacks)
+		for(var/obj/effect/cyberman_hack/human/hack in cyberman_network.active_cybermen_hacks)
 			if(hack.target == H)
 				user << "<span class='danger'>Unknown harmful microscopic machines detected in subject's bloodstream: Recommend treatment via Electro Magnetic Pulse or Strong Electric Shock immediately!</span>"
 				break

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -841,20 +841,22 @@ datum/admins/proc/cybermen_panel()
 		<A href='?_src_=holder;cybermen=1'>Refresh</A><br>
 		<center><B>Cybermen Panel</B></center><hr><BR><BR>
 		"}
-	if(!istype(ticker.mode, /datum/game_mode/cybermen))
-		dat += "The gamemode is not currently cybermen, or the round has not started."
+	if(!cyberman_network)
+		dat += "There is no Cyberman Network at this time. Creating a cyberman will automatically initialize a new network.<BR><A href='?_src_=holder;cybermen=7'>Initialize Network</A>"
 	else
 		dat += {"
 			<A href='?_src_=holder;cybermen=2'>Force Complete Current Objective</A>(automatically displays to all cybermen)<br>
 			<A href='?_src_=holder;cybermen=6'>Set Random Current Objective</A>(automatically displays to all cybermen)<br>
 			<A href='?_src_=holder;cybermen=4'>Display Current Objective to all Cybermen</A><br>
 			<A href='?_src_=holder;cybermen=5'>Message All Cybermen</A><br>
+			<A href='?_src_=holder;cybermen=8'>Show Broadcast Log</A><br>
+			<A href='?_src_=holder;cybermen=9'>Show Hacking Log</A><br>
 			"}
 
 		//<A href='?_src_=holder;cybermen=3'>Set Current Objective</A><br> //does not work at the moment.
 
 		dat += "<BR>Current Cybermen:<BR>"
-		for(var/datum/mind/M in ticker.mode.cybermen)
+		for(var/datum/mind/M in cyberman_network.cybermen)
 			if(M)
 				dat += "[M] "
 				if(M.current)
@@ -866,15 +868,15 @@ datum/admins/proc/cybermen_panel()
 			dat += "<BR>"
 
 		dat += "<BR>Cybermen objectives:<BR>"
-		for(var/i = 1 to ticker.mode.cybermen_objectives.len)
-			var/datum/objective/cybermen/O = ticker.mode.cybermen_objectives[i]
+		for(var/i = 1 to cyberman_network.cybermen_objectives.len)
+			var/datum/objective/cybermen/O = cyberman_network.cybermen_objectives[i]
 			if(O)
 				dat += "Phase [i]:[O.phase]<BR>[O.explanation_text]<BR><BR>"
 			else
 				dat += "ERROR - null in the objective list<BR>"
 
 		dat += "<BR>Current Active Hacks:<BR>"
-		for(var/obj/effect/cyberman_hack/H in ticker.mode.active_cybermen_hacks)
+		for(var/obj/effect/cyberman_hack/H in cyberman_network.active_cybermen_hacks)
 			if(H)
 				dat += "[H.target_name] ([H.progress]/[H.cost])"
 				if(istype(H, /obj/effect/cyberman_hack/multiple_vector))
@@ -885,11 +887,29 @@ datum/admins/proc/cybermen_panel()
 			else
 				dat += "ERROR - null in the hack list<BR>"
 		dat += "<BR>Objects Hacked:<BR>"
-		for(var/O in ticker.mode.cybermen_hacked_objects)
+		for(var/O in cyberman_network.cybermen_hacked_objects)
 			if(O)
 				dat += "[O]"
 			else
 				dat += "ERROR - null in the hacked items list."
 			dat += "<BR>"
-	usr << browse(dat, "window=admin2;size=400x600")
+	usr << browse(dat, "window=cybermen;size=400x600")
 	return
+
+datum/admins/proc/cyberman_broadcast_log()
+	var/dat = {"
+			<A href='?_src_=holder;cybermen=8'>Refresh</A><br><br>
+			<center>Cybermen Hacking Log</center><hr>
+			"}
+	for(var/entry in cyberman_network.cyberman_broadcast_log)
+		dat += "[entry]<BR>"
+	usr << browse(dat, "window=cybermen_broadcast;size=400x600")
+
+datum/admins/proc/cyberman_hacking_log()
+	var/dat = {"
+			<A href='?_src_=holder;cybermen=9'>Refresh</A><br><br>
+			<center>Cybermen Hacking Log</center><hr>
+			"}
+	for(var/entry in cyberman_network.hacking_log)
+		dat += "[entry]<BR>"
+	usr << browse(dat, "window=cybermen_hacking;size=400x600")

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -520,9 +520,9 @@
 					dat += "<tr><td><i>Monkey not found!</i></td></tr>"
 			dat += "</table>"
 
-		if(ticker.mode.cybermen.len > 0)
+		if(cyberman_network.cybermen.len > 0)
 			dat += "<br><table cellspacing=5><tr><td><B>Cybermen</B></td><td></td><td></td></tr>"
-			for(var/datum/mind/cyberman in ticker.mode.cybermen)
+			for(var/datum/mind/cyberman in cyberman_network.cybermen)
 				var/mob/M = cyberman.current
 				if(M)
 					dat += "<tr><td><a href='?_src_=holder;adminplayeropts=\ref[M]'>[M.real_name]</a>[M.client ? "" : " <i>(ghost)</i>"][M.stat == 2 ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -138,7 +138,13 @@
 				else
 					message_admins("[key_name_admin(usr)] tried to create a shadowling. Unfortunately, there were no candidates available.")
 					log_admin("[key_name(usr)] failed to create a shadowling.")
-
+			if("17")
+				if(src.makeCyberman())
+					message_admins("[key_name(usr)] created a cyberman.")
+					log_admin("[key_name(usr)] created a cyberman.")
+				else
+					message_admins("[key_name_admin(usr)] tried to create a cyberman. Unfortunately, there were no candidates available.")
+					log_admin("[key_name(usr)] failed to create a cyberman.")
 	else if(href_list["forceevent"])
 		if(!check_rights(R_FUN))	return
 		var/datum/round_event_control/E = locate(href_list["forceevent"]) in SSevent.control
@@ -2210,8 +2216,16 @@
 			if("3")//set objective
 				set_cybermen_objective()
 			if("4")//display objective
-				ticker.mode.display_current_cybermen_objective()
+				cyberman_network.display_current_cybermen_objective()
 			if("5")//message all cybermen
 				cybermen_collective_broadcast()
 			if("6")//set random objective
 				reroll_cybermen_objective()
+			if("7")//initialize network
+				if(!cyberman_network)
+					message_admins("[key_name_admin(usr)] attempted to initialize a Cyberman Network without any Cybermen.")
+					new /datum/cyberman_network()
+			if("8")//broadcast log
+				cyberman_broadcast_log()
+			if("9")//hacking log
+				cyberman_hacking_log()

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -19,6 +19,7 @@
 		<a href='?src=\ref[src];makeAntag=11'>Make Blob</a><br>
 		<a href='?src=\ref[src];makeAntag=12'>Make Gangsters</a><br>
 		<a href='?src=\ref[src];makeAntag=16'>Make Shadowling</a><br>
+		<a href='?src=\ref[src];makeAntag=17'>Make Cyberman</a><br>
 		<a href='?src=\ref[src];makeAntag=6'>Make Wizard (Requires Ghosts)</a><br>
 		<a href='?src=\ref[src];makeAntag=7'>Make Nuke Team (Requires Ghosts)</a><br>
 		<a href='?src=\ref[src];makeAntag=13'>Make Centcom Response Team (Requires Ghosts)</a><br>
@@ -677,6 +678,32 @@
 		is time you cast it away. You are a shadowling, and you are to ascend at all costs.</b></i></span>"
 		ticker.mode.finalize_shadowling(H.mind)
 		message_admins("[H] has been made into a shadowling.")
+		candidates.Remove(H)
+		return 1
+	return 0
+
+/datum/admins/proc/makeCyberman()
+	var/datum/game_mode/cybermen/temp = new
+	if(config.protect_roles_from_antagonist)
+		temp.restricted_jobs += temp.protected_jobs
+	if(config.protect_assistant_from_antagonist)
+		temp.restricted_jobs += "Assistant"
+	var/list/mob/living/carbon/human/candidates = list()
+	var/mob/living/carbon/human/H = null
+	for(var/mob/living/carbon/human/applicant in player_list)
+		//if(applicant.client.prefs.be_special & BE_CYBERMAN)//the pref doesn't work because the number is too big for the & operator.
+		if(!applicant.stat)
+			if(applicant.mind)
+				if(!applicant.mind.special_role)
+					if(temp.age_check(applicant.client))
+						if(!(applicant.job in temp.restricted_jobs))
+							if(!(ticker.mode.is_cyberman(applicant.mind)))
+								candidates += applicant
+
+	if(candidates.len)
+		H = pick(candidates)
+		ticker.mode.add_cyberman(H.mind)
+		message_admins("[H] has been made into a cyberman.")
 		candidates.Remove(H)
 		return 1
 	return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -88,10 +88,11 @@
 					stat("", mind.cyberman.selected_hack)
 				else
 					stat("Currently Processing Hack(auto): none")
-				for(var/obj/effect/cyberman_hack/hack in ticker.mode.active_cybermen_hacks)
-					if(hack != mind.cyberman.selected_hack)
-						hack.name = hack.get_status(src)
-						stat("", hack)
+				if(cyberman_network)
+					for(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)
+						if(hack != mind.cyberman.selected_hack)
+							hack.name = hack.get_status(src)
+							stat("", hack)
 
 	//NINJACODE
 	if(istype(wear_suit, /obj/item/clothing/suit/space/space_ninja)) //Only display if actually a ninja.
@@ -247,7 +248,7 @@
 		dat += "<tr><td><font color=grey><B>Uniform:</B></font></td><td><font color=grey>Obscured</font></td></tr>"
 	else
 		dat += "<tr><td><B>Uniform:</B></td><td><A href='?src=\ref[src];item=[slot_w_uniform]'>[(w_uniform && !(w_uniform.flags&ABSTRACT)) ? w_uniform : "<font color=grey>Empty</font>"]</A></td></tr>"
-	
+
 	if((w_uniform == null || (slot_w_uniform in obscured)) && !(dna && dna.species.nojumpsuit))
 		dat += "<tr><td><font color=grey>&nbsp;&#8627;<B>Pockets:</B></font></td></tr>"
 		dat += "<tr><td><font color=grey>&nbsp;&#8627;<B>ID:</B></font></td></tr>"
@@ -301,10 +302,11 @@
 				src << "<span class='notice'>You feel your heart beating again!</span>"
 	//CYBERMEN STUFF
 	//I'd prefer to have an event-listener setup. see emp_act in human_defense.
-	for(var/obj/effect/cyberman_hack/human/H in ticker.mode.active_cybermen_hacks)
-		if(H.target == src)
-			H.electrocute_act()
-			break
+	if(cyberman_network)
+		for(var/obj/effect/cyberman_hack/human/H in cyberman_network.active_cybermen_hacks)
+			if(H.target == src)
+				H.electrocute_act()
+				break
 	return ..(shock_damage,source,siemens_coeff,override)
 
 /mob/living/carbon/human/Topic(href, href_list)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -79,20 +79,8 @@
 				stat("Absorbed DNA", mind.changeling.absorbedcount)
 			if(mind.cyberman)
 				stat("Hacking Module: [mind.cyberman.quickhack ? "Enabled" : "Disabled"] [mind.cyberman.emp_hit ? "%$&ERROR EMP DAMAGE [mind.cyberman.emp_hit]% #?@": ""]")
-				if(mind.cyberman.selected_hack)
-					var/manual_selected = mind.cyberman.manual_selected_hack ? "(manual)" : "(auto)"
-					mind.cyberman.selected_hack.name = "Currently Processing Hack[manual_selected]: [mind.cyberman.selected_hack.get_status(src)]"//Could make this the line label, but it would push ALL the stat things to the right very, very far. \
-																																					I'm a bit concerned about changing the name of the hack itself, but it seems to work pretty well, even with multiple people.\
-																																					Also allows the use of verbs, including varedit, through the statpanel, which is very nice.\
-																																					I have plans to change this in the future, but it's convenient for now.
-					stat("", mind.cyberman.selected_hack)
-				else
-					stat("Currently Processing Hack(auto): none")
-				if(cyberman_network)
-					for(var/obj/effect/cyberman_hack/hack in cyberman_network.active_cybermen_hacks)
-						if(hack != mind.cyberman.selected_hack)
-							hack.name = hack.get_status(src)
-							stat("", hack)
+				for(var/obj/status_obj in mind.cyberman.get_status_objs(src))
+					stat("", status_obj)
 
 	//NINJACODE
 	if(istype(wear_suit, /obj/item/clothing/suit/space/space_ninja)) //Only display if actually a ninja.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -269,9 +269,10 @@ emp_act
 	if(ticker.mode.is_cyberman(src.mind))
 		src.mind.cyberman.emp_act(src, severity)
 	else
-		for(var/obj/effect/cyberman_hack/human/H in ticker.mode.active_cybermen_hacks)
-			if(H.target == src)
-				H.emp_act(severity)
+		if(cyberman_network)
+			for(var/obj/effect/cyberman_hack/human/H in cyberman_network.active_cybermen_hacks)
+				if(H.target == src)
+					H.emp_act(severity)
 	..()
 
 /mob/living/carbon/human/acid_act(acidpwr, toxpwr, acid_volume)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -760,7 +760,7 @@ var/list/slot_equipment_priority = list( \
 		if(mind.changeling)
 			add_stings_to_statpanel(mind.changeling.purchasedpowers)
 		if(mind.cyberman)
-			mind.cyberman.add_cyberman_abilities_to_statpanel()
+			mind.cyberman.add_cyberman_abilities_to_statpanel(src)
 	add_spells_to_statpanel(mob_spell_list)
 
 /mob/proc/add_spells_to_statpanel(list/spells)


### PR DESCRIPTION
Fixes #222 #223 and #225
Fixes several cybermen bugs:
*You can no longer use cyberman abilities while dead or unconcious.
*Hacking an AI upload now properly hacks the AI it is connected to.
*Attempting to use a cyberman ability (other than broadcast, since you used to be able to use that and it wouldn't) as a ghost no longer deconverts your dead/catatonic body
*You will (hopefully) no longer get a verb in the commands tab that lets you cancel a conversion of yourself while you are still human.
*You can no longer convert dead people into cybermen.
*Hacks no longer have crazy names.

Balance and Quality of Life changes:
*color of "you hear a faint sound of static" message when a cyberman starts a hack near you changed from blue to red.
*Hacking the RnD server cost reduced from 500 to 300.
*If the current objective is to make 60% of the station cybermen, converting a human will never cost more than 3000.
*All objectives that require a number of something to be reached now display progress in their description.

COMING SOON:
*Cybermen abilities have action icons
*Varediting hacks from the cybermen panel
*Medhuds will show that cybermen, and people being converted into cybermen, have a disease
*Health Scanners will reveal cybermen
*more hacks, including: Microwaves, all bots, locked cargo crates, grinders, sleepers, and more!
