### PR TITLE
Flying over tables with jetpack

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -9,6 +9,7 @@
 	var/datum/effect/effect/system/ion_trail_follow/ion_trail
 	var/on = 0.0
 	var/stabilization_on = 0
+	var/flying = 0 // Needed to control the PASSTABLE flag
 	var/volume_rate = 500              //Needed for borg jetpack transfer
 
 /obj/item/weapon/tank/jetpack/New()
@@ -33,24 +34,36 @@
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	on = !on
+	var/mob/living/carbon/human/C = usr
 	if(on)
 		icon_state = "[icon_state]-on"
 	//	item_state = "[item_state]-on"
 		ion_trail.start()
+		if(!has_gravity(C) && flying == 0)
+			C.pass_flags += PASSTABLE
 	else
 		icon_state = initial(icon_state)
 	//	item_state = initial(item_state)
 		ion_trail.stop()
+		if(!has_gravity(C) && flying == 0 && C.pass_flags & PASSTABLE) // so it removes PASSTABLE which they get when its on. Prevents loopholes.
+			C.pass_flags -= PASSTABLE
 	usr << "<span class='notice'>You toggle the jetpack [on? "on":"off"].</span>"
 	return
 
-
 /obj/item/weapon/tank/jetpack/proc/allow_thrust(num, mob/living/user)
+	var/mob/living/carbon/human/C = usr
 	if(!(src.on))
 		return 0
 	if((num < 0.005 || src.air_contents.total_moles() < num))
 		src.ion_trail.stop()
-		return 0
+		flying = 1
+		if(!has_gravity(C) && C.pass_flags & PASSTABLE && flying == 1)
+			C.pass_flags -= PASSTABLE
+	if((num > 0.9 || src.air_contents.total_moles() > num) && flying == 1)
+		if(C.pass_flags & PASSTABLE && src.on == on) // the final check to get rid of unwanted flags.
+			C.pass_flags -= PASSTABLE
+		flying = 0 //restores it back to normal.
+		return
 
 	var/datum/gas_mixture/G = src.air_contents.remove(num)
 
@@ -95,7 +108,7 @@
 /obj/item/weapon/tank/jetpack/oxygen/captain/New()
 	..()
 	air_contents.oxygen = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	
+
 /obj/item/weapon/tank/jetpack/oxygen/harness
 	name = "jet harness (oxygen)"
 	desc = "A lightweight tactical harness, used by those who don't want to be weighed down by traditional jetpacks."

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -164,7 +164,10 @@
 
 		on = !on
 		if(on)
+			var/mob/living/carbon/human/C = usr
 			ion_trail.start()
+			if(!has_gravity(C) && flying == 0)
+				C.pass_flags += PASSTABLE
 			tank = H.s_store
 			air_contents = tank.air_contents
 			SSobj.processing |= src
@@ -174,9 +177,12 @@
 		H << "<span class='notice'>You toggle the inbuilt jetpack [on? "on":"off"].</span>"
 
 /obj/item/weapon/tank/jetpack/suit/proc/turn_off()
+	var/mob/living/carbon/human/C = usr
 	on = 0
 	SSobj.processing -= src
 	ion_trail.stop()
+	if(!has_gravity(C) && flying == 0 && C.pass_flags & PASSTABLE) // so it removes PASSTABLE which they get when its on. Prevents loopholes.
+		C.pass_flags -= PASSTABLE
 	air_contents = null
 	tank = null
 	icon_state = initial(icon_state)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -34,7 +34,7 @@
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	on = !on
-	var/mob/living/carbon/human/C = usr
+	var/mob/living/C = usr
 	if(on)
 		icon_state = "[icon_state]-on"
 	//	item_state = "[item_state]-on"
@@ -51,7 +51,7 @@
 	return
 
 /obj/item/weapon/tank/jetpack/proc/allow_thrust(num, mob/living/user)
-	var/mob/living/carbon/human/C = usr
+	var/mob/living/C = usr
 	if(!(src.on))
 		return 0
 	if((num < 0.005 || src.air_contents.total_moles() < num))

--- a/html/changelogs/Super3222-JetpackBuff.yml
+++ b/html/changelogs/Super3222-JetpackBuff.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "If gravity is down and you are moving around with an activated jetpack, you can now fly over tables."


### PR DESCRIPTION
This will allow people who are using jetpacks (while they are on) to fly over tables whenever gravity is down in the area.

It works for everything defined as a jetpack, the captains own gold one, the carbon dixode one in EVA, the suit-inbuilt jetpack, etc.

Req. #82 
