### PR TITLE
Adds organ decay and makes heart transplants work

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -121,6 +121,17 @@ MASS SPECTROMETER
 	if(M.status_flags & FAKEDEATH)
 		mob_status = "<span class='alert'>Deceased</span>"
 		oxy_loss = max(rand(1, 40), oxy_loss, (300 - (tox_loss + fire_loss + brute_loss))) // Random oxygen loss
+		user << "<span class='danger'>Subject's heart tissue has decayed beyond the point of no return.</span>"//perhaps make this random too?
+	else
+		var/obj/item/organ/internal/heart/heart = M.getorgan(/obj/item/organ/internal/heart)
+		if(!heart)
+			user << "<span class='danger'>Subject does not have a heart.</span>"
+		else
+			if(heart.decay_time && (heart.decay != heart.decay_time))
+				if(heart.decay == -1)
+					user << "<span class='danger'>Subject's heart tissue has decayed beyond the point of no return.</span>"
+				else
+					user << "<span class='danger'>Subject's heart tissue is [round(100-(100*heart.decay/heart.decay_time), 0.1)]% decayed.</span>"
 
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -410,7 +410,7 @@
 				user.visible_message("<span class='notice'>[user] places [src] on [M.name]'s chest.</span>", "<span class='warning'>You place [src] on [M.name]'s chest.</span>")
 				playsound(get_turf(src), 'sound/machines/defib_charge.ogg', 50, 0)
 				var/tplus = world.time - H.timeofdeath
-				var/tlimit = 6000 //past this much time the patient is unrecoverable (in deciseconds)
+				var/tlimit = 6000 //Marker for how much brain damage a person will take.
 				var/tloss = 3000 //brain damage starts setting in on the patient after some time left rotting
 				var/total_burn	= 0
 				var/total_brute	= 0
@@ -431,10 +431,10 @@
 						total_burn	= H.getFireLoss()
 
 						var/failed = null
-
+						var/obj/item/organ/internal/heart/the_heart = H.getorgan(/obj/item/organ/internal/heart)
 						if (H.suiciding || (NOCLONE in H.mutations))
 							failed = "<span class='warning'>[defib] buzzes: Resuscitation failed - Recovery of patient impossible. Further attempts futile.</span>"
-						else if ((tplus > tlimit) || !H.getorgan(/obj/item/organ/internal/heart))
+						else if (!the_heart || the_heart.decay == -1)
 							failed = "<span class='warning'>[defib] buzzes: Resuscitation failed - Heart tissue damage beyond point of no return. Further attempts futile.</span>"
 						else if(total_burn >= 180 || total_brute >= 180)
 							failed = "<span class='warning'>[defib] buzzes: Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator. Further attempts futile.</span>"

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -1,5 +1,25 @@
 /obj/structure/closet/secure_closet/freezer
 	icon_state = "freezer"
+	var/target_temp = T0C - 40//and now they actually freeze stuff
+	var/cooling_power = 40
+
+/obj/structure/closet/secure_closet/freezer/return_air()//copied from crates.dm
+	var/datum/gas_mixture/gas = (..())
+	if(!gas)	return null
+	var/datum/gas_mixture/newgas = new/datum/gas_mixture()
+	newgas.oxygen = gas.oxygen
+	newgas.carbon_dioxide = gas.carbon_dioxide
+	newgas.nitrogen = gas.nitrogen
+	newgas.toxins = gas.toxins
+	newgas.volume = gas.volume
+	newgas.temperature = gas.temperature
+	if(newgas.temperature <= target_temp)	return
+
+	if((newgas.temperature - cooling_power) > target_temp)
+		newgas.temperature -= cooling_power
+	else
+		newgas.temperature = target_temp
+	return newgas
 
 /obj/structure/closet/secure_closet/freezer/kitchen
 	name = "kitchen Cabinet"

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -7,6 +7,45 @@
 	var/slot
 	var/vital = 0
 	var/organ_action_name = null
+	var/decay_time = 0//Measured in BYOND seconds. By default, organs do not decay.
+	var/decay = 0
+	var/decay_above_temp = T0C
+
+/obj/item/organ/internal/New()
+	decay = decay_time
+	if(decay_time)
+		SSobj.processing |= src
+
+/obj/item/organ/internal/process()
+	if(!decay_time || decay == -1)
+		return
+	if(owner && !(owner.stat & DEAD))//don't decay if you are inside a living person.
+		return
+	var/datum/gas_mixture/environment = null
+	if(owner)
+		environment = owner.return_air()
+	else if(loc)
+		environment = loc.return_air()
+	if(!environment)
+		return
+	if(environment.temperature > decay_above_temp)
+		decay = max(0, decay-1)
+	if(!decay)
+		on_decay()
+
+/obj/item/organ/internal/proc/on_decay()
+	decay = -1
+	SSobj.processing.Remove(src)
+
+/obj/item/organ/internal/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/device/healthanalyzer))//perhaps also the PDA cartridge?
+		user.visible_message("<span class='notice'>[user] has analyzed \the [src].</span>")
+		if(!decay_time)
+			user << "<span class='danger'>\The [src] will not decay.</span>"
+		else if(decay == -1)
+			user << "<span class='danger'>\The [src] is decayed beyond the point of no return.</span>"
+		else
+			user << "<span class='danger'>\The [src]'s tissue is [round(100-(100*decay/decay_time), 0.1)]% decayed.</span>"
 
 /obj/item/organ/internal/proc/Insert(mob/living/carbon/M, special = 0)
 	if(!iscarbon(M) || owner == M)
@@ -37,6 +76,7 @@
 	return
 
 /obj/item/organ/internal/proc/on_life()
+	decay = min(decay_time, decay+1)
 	return
 
 /obj/item/organ/internal/proc/prepare_eat()
@@ -81,7 +121,13 @@
 	slot = "heart"
 	origin_tech = "biotech=3"
 	vital = 1
+	decay_time = 600//10 BYOND minutes, same as the old defib time limit.
 	var/beating = 1
+
+/obj/item/organ/internal/heart/on_decay()
+	..()
+	beating = 0
+	update_icon()
 
 /obj/item/organ/internal/heart/update_icon()
 	if(beating)
@@ -96,9 +142,11 @@
 
 /obj/item/organ/internal/heart/Remove(mob/living/carbon/M, special = 0)
 	..()
+	/*//unnecessary with the new decay system.
 	spawn(120)
 		beating = 0
 		update_icon()
+	*/
 
 /obj/item/organ/internal/heart/prepare_eat()
 	var/obj/S = ..()

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -21,14 +21,19 @@
 		return
 	if(owner && !(owner.stat & DEAD))//don't decay if you are inside a living person.
 		return
-	var/datum/gas_mixture/environment = null
+
+	var/temperature
 	if(owner)
-		environment = owner.return_air()
+		temperature = owner.bodytemperature
 	else if(loc)
-		environment = loc.return_air()
-	if(!environment)
+		var/datum/gas_mixture/environment = loc.return_air()
+		if(!environment)
+			return
+		temperature = environment.temperature
+	else
 		return
-	if(environment.temperature > decay_above_temp)
+
+	if(temperature > decay_above_temp)
 		decay = max(0, decay-1)
 	if(!decay)
 		on_decay()


### PR DESCRIPTION
*Organs now have a decay timer that counts down when the organ's owner is dead or the organ is not in someone's body. This can be halted by putting the organ somewhere cold.
*Only hearts currently decay by default. They will not decay if the temperature is 0 degrees Celsius or colder. The decay time is 10 minutes, the same as the old defib time limit.
*Refrigerator lockers now cool down their contents just like freezer crates.
*Defibs now work off the new decay system instead of time of death, making heart transplants possible.

Inspired by this thread: http://forums.yogstation.net/index.php?threads/heart-transplant.8709/
