### PR TITLE
Updated PDAs 

### DIFF
--- a/code/__DEFINES/pda.dm
+++ b/code/__DEFINES/pda.dm
@@ -1,0 +1,3 @@
+#define PDA_ATMOS_ALERT 1
+#define PDA_FIRE_ALERT 2
+#define PDA_POWER_ALERT 4

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -14,6 +14,11 @@
 
 
 // ===
+
+var/list/power_alert_listeners = list()
+var/list/atmos_alert_listeners = list()
+var/list/fire_alert_listeners = list()
+
 /area
 	var/global/global_uid = 0
 	var/uid
@@ -72,10 +77,17 @@
 					D.cancelAlarm("Power", src, source)
 				else
 					D.triggerAlarm("Power", src, cameras, source)
+			for(var/listener in power_alert_listeners)
+				if(state == 1)
+					listener:cancelAlarm("Power", src, source)
+				else
+					listener:triggerAlarm("Power", src, cameras, source)
+
 	return
 
 /area/proc/atmosalert(danger_level, obj/source)
 	if(danger_level != atmosalm)
+
 		if (danger_level==2)
 			var/list/cameras = list()
 			for(var/area/RA in related)
@@ -88,6 +100,8 @@
 				a.triggerAlarm("Atmosphere", src, cameras, source)
 			for(var/mob/living/simple_animal/drone/D in mob_list)
 				D.triggerAlarm("Atmosphere", src, cameras, source)
+			for(var/listener in atmos_alert_listeners)
+				listener:triggerAlarm("Atmosphere", src, cameras, source)
 
 		else if (src.atmosalm == 2)
 			for(var/mob/living/silicon/aiPlayer in player_list)
@@ -96,6 +110,8 @@
 				a.cancelAlarm("Atmosphere", src, source)
 			for(var/mob/living/simple_animal/drone/D in mob_list)
 				D.cancelAlarm("Atmosphere", src, source)
+			for(var/listener in atmos_alert_listeners)
+				listener:cancelAlarm("Atmosphere", src, source)
 
 		src.atmosalm = danger_level
 		return 1
@@ -128,6 +144,8 @@
 		aiPlayer.triggerAlarm("Fire", src, cameras, source)
 	for (var/mob/living/simple_animal/drone/D in mob_list)
 		D.triggerAlarm("Fire", src, cameras, source)
+	for(var/listener in fire_alert_listeners)
+		listener:triggerAlarm("Fire", src, cameras, source)
 	return
 
 /area/proc/firereset(obj/source)
@@ -152,6 +170,8 @@
 		a.cancelAlarm("Fire", src, source)
 	for (var/mob/living/simple_animal/drone/D in mob_list)
 		D.cancelAlarm("Fire", src, source)
+	for(var/listener in fire_alert_listeners)
+		listener:cancelAlarm("Fire", src, source)
 	return
 
 /area/proc/burglaralert(obj/trigger)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1,8 +1,14 @@
-
 //The advanced pea-green monochrome lcd of tomorrow.
 
 var/global/list/obj/item/device/pda/PDAs = list()
 
+#define PDA_SCAN_MEDICAL 1
+#define PDA_SCAN_FORENSICS 2
+#define PDA_SCAN_REAGENT 3
+#define PDA_SCAN_HALOGEN 4
+#define PDA_SCAN_GAS 5
+#define PDA_SCAN_FLORAL 6
+#define PDA_SCAN_POWER 7
 
 /obj/item/device/pda
 	name = "\improper PDA"
@@ -319,21 +325,42 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					if (istype(cartridge, /obj/item/weapon/cartridge/slavemaster))
 						dat += "<li><a href='byond://?src=\ref[src];choice=48'><img src=pda_signaler.png> Slavemaster 2000</a></li>"
 					dat += "</ul>"
-					if (cartridge.access_engine)
+					if (cartridge.access_engine || (cartridge.alert_flags & PDA_POWER_ALERT))
 						dat += "<h4>Engineering Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=43'><img src=pda_power.png> Power Monitor</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Halogen Counter'><img src=pda_reagent.png> [scanmode == PDA_SCAN_HALOGEN ? "Disable" : "Enable"] Halogen Counter</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Power Meter'><img src=pda_reagent.png> [scanmode == PDA_SCAN_POWER ? "Disable" : "Enable"] Power Meter</a></li>"
+						if(cartridge.alert_flags & PDA_POWER_ALERT)
+							dat += "<li><a href='byond://?src=\ref[src];choice=power alerts'><img src=pda_signaler.png> [(cartridge.alert_toggles & PDA_POWER_ALERT) ? "Disable" : "Enable"] Power Alert Notifications</a></li>"
+						dat += "</ul>"
+					if (cartridge.access_atmos || cartridge.access_atmos_sensors || (cartridge.alert_flags & PDA_ATMOS_ALERT) || (cartridge.alert_flags & PDA_FIRE_ALERT))
+						dat += "<h4>Atmospherics Functions:</h4>"
+						dat += "<ul>"
+						if(cartridge.access_atmos)
+							dat += "<li><a href='byond://?src=\ref[src];choice=Gas Scan'><img src=pda_reagent.png> [scanmode == PDA_SCAN_GAS ? "Disable" : "Enable"] Gas Scanner</a></li>"
+						if(cartridge.access_atmos_sensors)
+							dat += "<li><a href='byond://?src=\ref[src];choice=50'><img src=pda_power.png> Atmospherics Monitor</a></li>"
+						if(cartridge.alert_flags & PDA_ATMOS_ALERT)
+							dat += "<li><a href='byond://?src=\ref[src];choice=atmos alerts'><img src=pda_signaler.png> [(cartridge.alert_toggles & PDA_ATMOS_ALERT) ? "Disable" : "Enable"] Atmos Alert Notifications</a></li>"
+						if(cartridge.alert_flags & PDA_FIRE_ALERT)
+							dat += "<li><a href='byond://?src=\ref[src];choice=fire alerts'><img src=pda_signaler.png> [(cartridge.alert_toggles & PDA_FIRE_ALERT) ? "Disable" : "Enable"] Fire Alert Notifications</a></li>"
 						dat += "</ul>"
 					if (cartridge.access_medical)
 						dat += "<h4>Medical Functions</h4>"
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=44'><img src=pda_medical.png> Medical Records</a></li>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png> [scanmode == 1 ? "Disable" : "Enable"] Medical Scanner</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Medical Scan'><img src=pda_scanner.png> [scanmode == PDA_SCAN_MEDICAL ? "Disable" : "Enable"] Medical Scanner</a></li>"
+						dat += "</ul>"
+					if (cartridge.access_reagent_scanner)
+						dat += "<h4>Chemistry Functions:</h4>"
+						dat += "<ul>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Reagent Scan'><img src=pda_reagent.png> [scanmode == PDA_SCAN_REAGENT ? "Disable" : "Enable"] Reagent Scanner</a></li>"
 						dat += "</ul>"
 					if (cartridge.access_flora)
 						dat += "<h4>Botanist Functions</h4>"
 						dat += "<ul>"
-						dat += "<li><a href='byond://?src=\ref[src];choice=Plant Analyze'><img src=pda_botany.png> [scanmode == 6 ? "Disable" : "Enable"] Plant Analyzer</a></li>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=Plant Analyze'><img src=pda_botany.png> [scanmode == PDA_SCAN_FLORAL ? "Disable" : "Enable"] Plant Analyzer</a></li>"
 						dat += "</ul>"
 					if (cartridge.access_security)
 						dat += "<h4>Security Functions</h4>"
@@ -345,6 +372,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 						dat += "<ul>"
 						dat += "<li><a href='byond://?src=\ref[src];choice=47'><img src=pda_crate.png> Supply Records</A></li>"
 						dat += "</ul>"
+					if(cartridge.access_janitor)
+						dat += "<h4>Janitorial Functions:</h4>"
+						dat += "<ul>"
+						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png> Custodial Locator</a></li>"
+						dat += "</ul>"
+
 				dat += "</ul>"
 
 				dat += "<h4>Utilities</h4>"
@@ -352,18 +385,12 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if (cartridge)
 					if(cartridge.bot_access_flags)
 						dat += "<li><a href='byond://?src=\ref[src];choice=54'><img src=pda_medbot.png> Bots Access</a></li>"
-					if (cartridge.access_janitor)
-						dat += "<li><a href='byond://?src=\ref[src];choice=49'><img src=pda_bucket.png> Custodial Locator</a></li>"
+					if(cartridge.alert_flags)
+						dat += "<li><a href='byond://?src=\ref[src];choice=51'><img src=pda_medbot.png> View Alerts</a></li>"
 					if (istype(cartridge.radio, /obj/item/radio/integrated/signal))
 						dat += "<li><a href='byond://?src=\ref[src];choice=40'><img src=pda_signaler.png> Signaler System</a></li>"
 					if (cartridge.access_newscaster)
 						dat += "<li><a href='byond://?src=\ref[src];choice=53'><img src=pda_notes.png> Newscaster Access </a></li>"
-					if (cartridge.access_reagent_scanner)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Reagent Scan'><img src=pda_reagent.png> [scanmode == 3 ? "Disable" : "Enable"] Reagent Scanner</a></li>"
-					if (cartridge.access_engine)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Halogen Counter'><img src=pda_reagent.png> [scanmode == 4 ? "Disable" : "Enable"] Halogen Counter</a></li>"
-					if (cartridge.access_atmos)
-						dat += "<li><a href='byond://?src=\ref[src];choice=Gas Scan'><img src=pda_reagent.png> [scanmode == 5 ? "Disable" : "Enable"] Gas Scanner</a></li>"
 					if (cartridge.access_remote_door)
 						dat += "<li><a href='byond://?src=\ref[src];choice=Toggle Door'><img src=pda_rdoor.png> Toggle Remote Door</a></li>"
 
@@ -553,25 +580,30 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					if(src in U.contents)	U.AddLuminosity(f_lum)
 					else					SetLuminosity(f_lum)
 			if("Medical Scan")
-				if(scanmode == 1)
+				if(scanmode == PDA_SCAN_MEDICAL)
 					scanmode = 0
 				else if((!isnull(cartridge)) && (cartridge.access_medical))
-					scanmode = 1
+					scanmode = PDA_SCAN_MEDICAL
 			if("Plant Analyze")
-				if(scanmode == 6)
+				if(scanmode == PDA_SCAN_FLORAL)
 					scanmode = 0
 				else if ((!isnull(cartridge)) && (cartridge.access_flora))
-					scanmode = 6
+					scanmode = PDA_SCAN_FLORAL
 			if("Reagent Scan")
-				if(scanmode == 3)
+				if(scanmode == PDA_SCAN_REAGENT)
 					scanmode = 0
 				else if((!isnull(cartridge)) && (cartridge.access_reagent_scanner))
-					scanmode = 3
+					scanmode = PDA_SCAN_REAGENT
 			if("Halogen Counter")
-				if(scanmode == 4)
+				if(scanmode == PDA_SCAN_HALOGEN)
 					scanmode = 0
 				else if((!isnull(cartridge)) && (cartridge.access_engine))
-					scanmode = 4
+					scanmode = PDA_SCAN_HALOGEN
+			if("Power Meter")
+				if(scanmode == PDA_SCAN_POWER)
+					scanmode = 0
+				else if((!isnull(cartridge)) && (cartridge.access_engine))
+					scanmode = PDA_SCAN_POWER
 			if("Honk")
 				if ( !(last_noise && world.time < last_noise + 20) )
 					playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
@@ -581,10 +613,23 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					playsound(loc, 'sound/misc/sadtrombone.ogg', 50, 1)
 					last_noise = world.time
 			if("Gas Scan")
-				if(scanmode == 5)
+				if(scanmode == PDA_SCAN_GAS)
 					scanmode = 0
 				else if((!isnull(cartridge)) && (cartridge.access_atmos))
-					scanmode = 5
+					scanmode = PDA_SCAN_GAS
+
+//ALERT FUNCTIONS========================================
+			if("power alerts")
+				if(cartridge)
+					cartridge.alert_toggles ^= PDA_POWER_ALERT
+
+			if("atmos alerts")
+				if(cartridge)
+					cartridge.alert_toggles ^= PDA_ATMOS_ALERT
+
+			if("fire alerts")
+				if(cartridge)
+					cartridge.alert_toggles ^= PDA_FIRE_ALERT
 
 //NOTEKEEPER FUNCTIONS===================================
 
@@ -998,15 +1043,15 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(istype(C))
 		switch(scanmode)
 
-			if(1)
+			if(PDA_SCAN_MEDICAL)
 				user.visible_message(text("<span class='alert'>[] has analyzed []'s vitals!</span>", user, C))
 				healthscan(user, C, 1)
 				src.add_fingerprint(user)
 
-			if(2)
+			if(PDA_SCAN_FORENSICS)
 				// Unused
 
-			if(4)
+			if(PDA_SCAN_HALOGEN)
 				C.visible_message("<span class='warning'>[user] has analyzed [C]'s radiation levels!</span>")
 
 				user.show_message("<span class='notice'>Analyzing Results for [C]:</span>")
@@ -1019,7 +1064,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	if(!proximity) return
 	switch(scanmode)
 
-		if(3)
+		if(PDA_SCAN_REAGENT)
 			if(!isnull(A.reagents))
 				if(A.reagents.reagent_list.len > 0)
 					var/reagents_length = A.reagents.reagent_list.len
@@ -1031,7 +1076,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 			else
 				user << "<span class='notice'>No significant chemical agents found in [A].</span>"
 
-		if(5)
+		if(PDA_SCAN_GAS)
 			if (istype(A, /obj/item/weapon/tank))
 				var/obj/item/weapon/tank/T = A
 				atmosanalyzer_scan(T.air_contents, user, T)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -1,3 +1,4 @@
+
 /obj/item/weapon/cartridge
 	name = "generic cartridge"
 	desc = "A data cartridge for portable microcomputers."
@@ -10,6 +11,7 @@
 	var/access_security = 0
 	var/access_engine = 0
 	var/access_atmos = 0
+	var/access_atmos_sensors = 0
 	var/access_medical = 0
 	var/access_manifest = 0
 	var/access_clown = 0
@@ -22,8 +24,12 @@
 	var/remote_door_id = ""
 	var/access_status_display = 0
 	var/access_quartermaster = 0
-	var/access_hydroponics = 0
 	var/bot_access_flags = 0 //Bit flags. Selection: SEC_BOT|MULE_BOT|FLOOR_BOT|CLEAN_BOT|MED_BOT
+	var/alert_flags = 0
+	var/list/area/atmos_alerts = list()
+	var/list/area/fire_alerts = list()
+	var/list/area/power_alerts = list()
+	var/alert_toggles = 0
 
 	var/mode = null
 	var/menu
@@ -32,6 +38,8 @@
 	var/datum/data/record/active3 = null //Security
 	var/obj/machinery/computer/monitor/powmonitor = null // Power Monitor
 	var/list/powermonitors = list()
+	var/obj/machinery/computer/general_air_control/atmosmonitor = null
+	var/list/atmosmonitors = list()
 	var/message1	// used for status_displays
 	var/message2
 	var/list/stored_data = list()
@@ -40,17 +48,35 @@
 	var/obj/machinery/bot/active_bot
 	var/list/botlist = list()
 
+/obj/item/weapon/cartridge/New()
+	..()
+	if(alert_flags & PDA_ATMOS_ALERT)
+		atmos_alert_listeners |= src
+	if(alert_flags & PDA_POWER_ALERT)
+		power_alert_listeners |= src
+	if(alert_flags & PDA_FIRE_ALERT)
+		fire_alert_listeners |= src
+
+/obj/item/weapon/cartridge/Destroy()
+	atmos_alert_listeners -= src
+	power_alert_listeners -= src
+	fire_alert_listeners -= src
+	return ..()
+
 /obj/item/weapon/cartridge/engineering
 	name = "\improper Power-ON cartridge"
 	icon_state = "cart-e"
 	access_engine = 1
 	bot_access_flags = FLOOR_BOT
+	alert_flags = PDA_POWER_ALERT
 
 /obj/item/weapon/cartridge/atmos
 	name = "\improper BreatheDeep cartridge"
 	icon_state = "cart-a"
 	access_atmos = 1
+	access_atmos_sensors = 1
 	bot_access_flags = FLOOR_BOT
+	alert_flags = PDA_ATMOS_ALERT|PDA_FIRE_ALERT
 
 /obj/item/weapon/cartridge/medical
 	name = "\improper Med-U cartridge"
@@ -175,7 +201,9 @@
 	access_status_display = 1
 	access_engine = 1
 	access_atmos = 1
+	access_atmos_sensors = 1
 	bot_access_flags = FLOOR_BOT
+	alert_flags = PDA_ATMOS_ALERT|PDA_FIRE_ALERT|PDA_POWER_ALERT
 
 /obj/item/weapon/cartridge/cmo
 	name = "\improper Med-U DELUXE cartridge"
@@ -201,7 +229,7 @@
 
 /obj/item/weapon/cartridge/captain
 	name = "\improper Value-PAK cartridge"
-	desc = "Now with 350% more value!" //Give the Captain...EVERYTHING! (Except Mime and Clown)
+	desc = "Now with 450% more value!" //Give the Captain...EVERYTHING! (Except Mime and Clown)
 	icon_state = "cart-c"
 	access_manifest = 1
 	access_engine = 1
@@ -210,10 +238,13 @@
 	access_reagent_scanner = 1
 	access_status_display = 1
 	access_atmos = 1
+	access_atmos_sensors = 1
 	access_newscaster = 1
 	access_quartermaster = 1
 	access_janitor = 1
+	access_flora = 1
 	bot_access_flags = SEC_BOT|MULE_BOT|FLOOR_BOT|CLEAN_BOT|MED_BOT
+	alert_flags = PDA_ATMOS_ALERT|PDA_FIRE_ALERT|PDA_POWER_ALERT
 
 /obj/item/weapon/cartridge/captain/New()
 	..()
@@ -249,6 +280,64 @@
 			loc:attack_self(M)
 
 	return
+
+/obj/item/weapon/cartridge/proc/triggerAlarm(class, area/A, O, obj/alarmsource)
+	var/msg
+	switch(class)
+		if("Atmosphere")
+			if(!(alert_flags & PDA_ATMOS_ALERT))
+				return
+			atmos_alerts += A
+			if(alert_toggles & PDA_ATMOS_ALERT)
+				msg = "Alert: Atmos alarm in \the [A]"
+		if("Power")
+			if(!(alert_flags & PDA_POWER_ALERT))
+				return
+			power_alerts += A
+			if(alert_toggles & PDA_POWER_ALERT)
+				msg = "Alert: Power alarm in \the [A]"
+		if("Fire")
+			if(!(alert_flags & PDA_FIRE_ALERT))
+				return
+			fire_alerts += A
+			if(alert_toggles & PDA_FIRE_ALERT)
+				msg = "Alert: Fire alarm in \the [A]"
+		else
+			return
+	if(istype(loc, /obj/item/device/pda))
+		var/obj/item/device/pda/pda = loc
+		if(!pda.silent && msg)
+			playsound(pda.loc, 'sound/machines/twobeep.ogg', 50, 1)
+			pda.audible_message("\icon[pda] [msg]", null, 3)
+
+/obj/item/weapon/cartridge/proc/cancelAlarm(class, area/A, obj/origin)
+	var/msg
+	switch(class)
+		if("Atmosphere")
+			if(!(alert_flags & PDA_ATMOS_ALERT))
+				return
+			atmos_alerts -= A
+			if(alert_toggles & PDA_ATMOS_ALERT)
+				msg = "Notice: Atmos alarm cleared in \the [A]"
+		if("Power")
+			if(!(alert_flags & PDA_POWER_ALERT))
+				return
+			power_alerts -= A
+			if(alert_toggles & PDA_POWER_ALERT)
+				msg = "Notice: Power alarm cleared in \the [A]"
+		if("Fire")
+			if(!(alert_flags & PDA_FIRE_ALERT))
+				return
+			fire_alerts -= A
+			if(alert_toggles & PDA_FIRE_ALERT)
+				msg = "Notice: Fire alarm cleared in \the [A]"
+		else
+			return
+	if(istype(loc, /obj/item/device/pda))
+		var/obj/item/device/pda/pda = loc
+		if(!pda.silent && msg)
+			playsound(pda.loc, 'sound/machines/twobeep.ogg', 50, 1)
+			pda.audible_message("\icon[pda] [msg]", null, 3)
 
 /obj/item/weapon/cartridge/proc/post_status(command, data1, data2)
 
@@ -577,6 +666,72 @@ Code:
 			else
 				menu += "ERROR: Unable to determine current location."
 			menu += "<br><br><A href='byond://?src=\ref[src];choice=49'>Refresh GPS Locator</a>"
+		if(50)//atmos monitoring
+			menu = "<h4><img src=pda_power.png> Atmosphere Monitors - Please select one</h4><BR>"
+			atmosmonitor = null
+			atmosmonitors = list()
+
+			for(var/obj/machinery/computer/general_air_control/aMon in world)
+				if(!(aMon.stat & (NOPOWER|BROKEN)) )
+					atmosmonitors += aMon
+			if(!atmosmonitors.len)
+				menu += "<span class='danger'>No connection<BR></span>"
+			else
+				menu += "<FONT SIZE=-1>"
+				var/count = 0
+				for(var/obj/machinery/computer/general_air_control/aMon in atmosmonitors)
+					count++
+					menu += "<a href='byond://?src=\ref[src];choice=Atmos Select;target=[count]'>[aMon] </a><BR>"
+				menu += "</FONT>"
+		if(501)
+			menu = "<h4><img src=pda_power.png> Atmosphere Monitor</h4><BR>"
+			if(!atmosmonitor.sensors.len)
+				menu += "<span class='danger'>No connection<BR></span>"
+			else
+				for(var/id_tag in atmosmonitor.sensors)
+					var/list/data = atmosmonitor.sensor_information[id_tag]
+					menu += "<b>[atmosmonitor.sensors[id_tag]]</b><ul>"
+					if(data)
+						if(data["pressure"])
+							menu += "<li><B>Pressure:</B> [data["pressure"]] kPa<BR></li>"
+						else
+							menu += "<li><B>Pressure:</B> No pressure detected<BR></li>"
+						if(data["temperature"])
+							menu += "<li><B>Temperature:</B> [data["temperature"]] K<BR></li>"
+						if(data["oxygen"]||data["toxins"]||data["nitrogen"]||data["carbon_dioxide"])
+							menu += "<li><B>Gas Composition : </B></li>"
+							if(data["oxygen"])
+								menu += "<li>[data["oxygen"]]% O2;</li>"
+							if(data["nitrogen"])
+								menu += "<li>[data["nitrogen"]]% N;</li>"
+							if(data["carbon_dioxide"])
+								menu += "<li>[data["carbon_dioxide"]]% CO2;</li>"
+							if(data["toxins"])
+								menu += "<li>[data["toxins"]]% TX;</li>"
+						menu += "</ul>"
+
+					else
+						menu = "<FONT class='bad'>[atmosmonitor.sensors[id_tag]] can not be found!</FONT><BR>"
+
+		if(51)//alerts monitoring
+			menu = "<h4><img src=pda_signaler.png> Active Alerts</h4><BR>"
+			if(alert_flags & PDA_ATMOS_ALERT)
+				menu += "<b>Atmosphere Alerts:</b><ul>"
+				for(var/alert in atmos_alerts)
+					menu += "<li>[alert]</li>"
+				menu += "</ul>"
+
+			if(alert_flags & PDA_FIRE_ALERT)
+				menu += "<b>Fire Alerts:</b><ul>"
+				for(var/alert in fire_alerts)
+					menu += "<li>[alert]</li>"
+				menu += "</ul>"
+
+			if(alert_flags & PDA_POWER_ALERT)
+				menu += "<b>Power Alerts:</b><ul>"
+				for(var/alert in power_alerts)
+					menu += "<li>[alert]</li>"
+				menu += "</ul>"
 
 		if (53) // Newscaster
 			menu = "<h4><img src=pda_notes.png> Newscaster Access</h4>"
@@ -667,6 +822,12 @@ Code:
 			powmonitor = powermonitors[pnum]
 			loc:mode = 433
 			mode = 433
+
+		if("Atmos Select")
+			var/pnum = text2num(href_list["target"])
+			atmosmonitor = atmosmonitors[pnum]
+			loc:mode = 501
+			mode = 501
 
 		if("Newscaster Access")
 			mode = 53

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -51,7 +51,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/attackby(obj/item/O, mob/user, params)
 	..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		var/msg
 		msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>\n"
 		switch(plant_type)
@@ -70,34 +70,11 @@
 		msg += "- Other substances: <i>[reagents.total_volume-reagents.get_reagent_amount("nutriment")]</i>\n"
 		msg += "*---------*</span>"
 		usr << msg
-		return
-	if (istype(O, /obj/item/device/pda))
-		var/obj/item/device/pda/A = O
-		if(A.scanmode == 6)
-			var/msg
-			msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>\n"
-			switch(plant_type)
-				if(0)
-					msg += "- Plant type: <i>Normal plant</i>\n"
-				if(1)
-					msg += "- Plant type: <i>Weed</i>.  Can grow in nutrient-poor soil.\n"
-				if(2)
-					msg += "- Plant type: <i>Mushroom</i>.  Can grow in dry soil.\n"
-			msg += "- Potency: <i>[potency]</i>\n"
-			msg += "- Yield: <i>[yield]</i>\n"
-			msg += "- Maturation speed: <i>[maturation]</i>\n"
-			msg += "- Production speed: <i>[production]</i>\n"
-			msg += "- Endurance: <i>[endurance]</i>\n"
-			msg += "- Nutritional value: <i>[reagents.get_reagent_amount("nutriment")]</i>\n"
-			msg += "- Other substances: <i>[reagents.total_volume-reagents.get_reagent_amount("nutriment")]</i>\n"
-			msg += "*---------*</span>"
-			usr << msg
-			return
 	return
 
 /obj/item/weapon/grown/attackby(obj/item/O, mob/user, params)
 	..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		var/msg
 		msg = "<span class='info'>*---------*\n This is \a <span class='name'>[src]</span>\n"
 		switch(plant_type)
@@ -458,7 +435,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple/gold/attackby(var/obj/item/O as obj, var/mob/user as mob, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Mineral Content: <i>[reagents.get_reagent_amount("gold")]%</i></span>"
 
 
@@ -670,7 +647,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/chili/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Capsaicin: <i>[reagents.get_reagent_amount("capsaicin")]%</i></span>"
 
 
@@ -690,7 +667,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/icepepper/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Frost Oil: <i>[reagents.get_reagent_amount("frostoil")]%</i></span>"
 
 
@@ -711,7 +688,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Capsaicin: <i>[reagents.get_reagent_amount("capsaicin")]%</i></span>"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili/attack_hand(mob/user)
@@ -1075,7 +1052,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Anti-Toxin: <i>[reagents.get_reagent_amount("charcoal")]%</i></span>"
 		user << "<span class='info'>- Morphine: <i>[reagents.get_reagent_amount("morphine")]%</i></span>"
 
@@ -1095,7 +1072,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/amanita/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Amatoxins: <i>[reagents.get_reagent_amount("amatoxin")]%</i></span>"
 		user << "<span class='info'>- Mushroom Hallucinogen: <i>[reagents.get_reagent_amount("mushroomhallucinogen")]%</i></span>"
 
@@ -1115,7 +1092,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/angel/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Amatoxins: <i>[reagents.get_reagent_amount("amatoxin")]%</i></span>"
 		user << "<span class='info'>- Mushroom Hallucinogen: <i>[reagents.get_reagent_amount("mushroomhallucinogen")]%</i></span>"
 
@@ -1134,7 +1111,7 @@ obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy/add_juice()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/libertycap/attackby(obj/item/O, mob/user, params)
 	. = ..()
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "<span class='info'>- Mushroom Hallucinogen: <i>[reagents.get_reagent_amount("mushroomhallucinogen")]%</i></span>"
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/plumphelmet

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -10,6 +10,15 @@
 /obj/item/device/analyzer/plant_analyzer/attack_self(mob/user)
 	return 0
 
+/proc/is_plant_analyzer(var/O)
+	if(istype(O, /obj/item/device/analyzer/plant_analyzer))
+		return 1
+	if(istype(O, /obj/item/device/pda))
+		var/obj/item/device/pda/A = O
+		if(A.scanmode == PDA_SCAN_FLORAL)
+			return 1
+	return 0
+
 // *************************************
 // Hydroponics Tools
 // *************************************

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -713,7 +713,7 @@
 		else
 			user << "<span class='warning'>[src] already has seeds in it!</span>"
 
-	else if(istype(O, /obj/item/device/analyzer/plant_analyzer))
+	else if(is_plant_analyzer(O))
 		if(planted && myseed)
 			user << "*** <B>[myseed.plantname]</B> ***" //Carn: now reports the plants growing, not the seeds.
 			user << "-Plant Age: <span class='notice'>[age]</span>"
@@ -736,27 +736,6 @@
 		user << "-Water level: <span class='notice'>[waterlevel] / [maxwater]</span>"
 		user << "-Nutrition level: <span class='notice'>[nutrilevel] / [maxnutri]</span>"
 		user << ""
-	else if(istype(O, /obj/item/device/pda))
-		var/obj/item/device/pda/A = O
-		if(A.scanmode == 6)
-			if(planted && myseed)
-				visible_message("<span class='notice'[user] scans the plants in the hydroponic tray!</span>")
-				user << "*** <B>[myseed.plantname]</B> ***" //Carn: now reports the plants growing, not the seeds.
-				user << "-Plant Age: <span class='notice'>[age]</span>"
-				user << "-Plant Endurance: <span class='notice'>[myseed.endurance]</span>"
-				user << "-Plant Lifespan: <span class='notice'>[myseed.lifespan]</span>"
-				if(myseed.yield != -1)
-					user << "-Plant Yield: <span class='notice'>[myseed.yield]</span>"
-				user << "-Plant Production: <span class='notice'>[myseed.production]</span>"
-				if(myseed.potency != -1)
-					user << "-Plant Potency: <span class='notice'>[myseed.potency]</span>"
-				var/list/text_strings = myseed.get_analyzer_text()
-				if(text_strings)
-					for(var/string in text_strings)
-						user << string
-			else
-				user << "There are no plants in the tray!"
-
 	else if(istype(O, /obj/item/weapon/cultivator))
 		if(weedlevel > 0)
 			user.visible_message("[user] uproots the weeds.", "<span class='notice'>You remove the weeds from [src].</span>")

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -35,7 +35,7 @@
 	return
 
 /obj/item/seeds/attackby(obj/item/O, mob/user, params)
-	if (istype(O, /obj/item/device/analyzer/plant_analyzer))
+	if (is_plant_analyzer(O))
 		user << "*** <B>[plantname]</B> ***"
 		user << "-Plant Endurance: <span class='notice'>[endurance]</span>"
 		user << "-Plant Lifespan: <span class='notice'>[lifespan]</span>"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -130,6 +130,11 @@ By design, d1 is the smallest direction and d2 is the highest
 //
 /obj/structure/cable/attackby(obj/item/W, mob/user, params)
 	var/turf/T = src.loc
+	var/is_pda_multitool = 0
+	if(istype(W, /obj/item/device/pda/))
+		var/obj/item/device/pda/pda = W
+		if(pda.scanmode == PDA_SCAN_POWER)
+			is_pda_multitool = 1
 	if(T.intact)
 		return
 	if(istype(W, /obj/item/weapon/wirecutters))
@@ -148,13 +153,12 @@ By design, d1 is the smallest direction and d2 is the highest
 			return
 		coil.cable_join(src, user)
 
-	else if(istype(W, /obj/item/device/multitool))
+	else if(is_pda_multitool || istype(W, /obj/item/device/multitool))
 		if(powernet && (powernet.avail > 0))		// is it powered?
 			user << "<span class='danger'>[powernet.avail]W in power network.</span>"
 		else
 			user << "<span class='danger'>The cable is not powered.</span>"
 		shock(user, 5, 0.2)
-
 	else
 		if (W.flags & CONDUCT)
 			shock(user, 50, 0.7)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,7 +7,7 @@
 # NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
-Cruix = Overlord
+
 Aranclanos = TGCoder
 
 Ephemeralis = HeadCoder

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -7,7 +7,7 @@
 # NOTE: if the rank-name cannot be found in admin_ranks.txt, they will not be adminned! ~Carn #
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
-
+Cruix = Overlord
 Aranclanos = TGCoder
 
 Ephemeralis = HeadCoder

--- a/html/changelogs/Cruix-PDAupgrade.yml
+++ b/html/changelogs/Cruix-PDAupgrade.yml
@@ -1,0 +1,7 @@
+author: Cruix
+
+delete-after: true
+
+changes: 
+  - rscadd: "Nanotrasen has updated the PDA cartridges of the engineering department. Atmospheric technician PDAs now have remote access to all atmospheric monitoring consoles, and can be toggled to receive a notification of all fire and air alerts on the station. Engineer PDAs can now be toggled to recieve a notification of all power alerts on the station, and can activate a power meter function to measure the power contained in a wire on the ground, just like a multitool. Naturally, the Captain and CE's PDA cartridges have been upgraded with all these functions as well. As a result, the Captain's Value-PAK cartridge now contains 100% more value. In addition, some PDA functions have been moved from the 'utilities' menu to their own categories."
+  - bugfix: "Fixed some cases where the botanist's PDA cartridge would not make the PDA properly act like a plant analyzer."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -27,6 +27,7 @@
 #include "code\__DEFINES\machines.dm"
 #include "code\__DEFINES\math.dm"
 #include "code\__DEFINES\misc.dm"
+#include "code\__DEFINES\pda.dm"
 #include "code\__DEFINES\pipe_construction.dm"
 #include "code\__DEFINES\preferences.dm"
 #include "code\__DEFINES\qdel.dm"


### PR DESCRIPTION
Fixes #273 
*fixed some cases where the botanist's PDA would not act like a plant analyzer when it should. Removed some copy-pasted code.
*PDA cartridges can now receive atmos, fire, and power alerts. Atmos techs receive atmos and fire, Engineers receive power, and the CE and Captain receive all 3. Alert notifications can be toggled on, causing the PDA to beep and state alerts when they are received.
*Atmos tech, CE, and Captain cartridges can view all atmos monitoring consoles through their PDA, similar to how engineers can view power monitoring consoles.
*Changed scanmode magic numbers into #defines.
*Engineer PDA cartridges have a new scanmode that lets them measure power in wires like a multitool.
*Added some new menu categories, moved some options out of "Utilities".
*Captain's Value-PAK cartridge now has 100% more value.

I have tested this quite thoroughly, but I messed with so much bad PDA code that I would prefer lots of additional testing before it is pushed to live.
