### PR TITLE
You can now recycle cable restraints

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -112,6 +112,13 @@
 			user << "<span class='warning'>You need one rod to make a wired rod!</span>"
 			return
 
+/obj/item/weapon/restraints/handcuffs/cable/attack_self(mob/user)
+		var/obj/item/stack/cable_coil/new_coil = new /obj/item/stack/cable_coil
+		new_coil.amount = 15
+		qdel(src)
+		usr.put_in_hands(new_coil)
+		usr.visible_message("<span class='notice'>[user.name] unties the knot that holds together [src].</span>")
+
 /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg/attack(mob/living/carbon/C, mob/user)
 	if(isrobot(user))
 		if(!C.handcuffed)

--- a/html/changelogs/Super3222-RecyclingCables.yml
+++ b/html/changelogs/Super3222-RecyclingCables.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - tweak: "Cable restraints can now be recycled by untying them in your hand."


### PR DESCRIPTION
#255.

Cable restraints can be recycled back into coils by untying them in your hand.

Furthermore, the other request will probably be in another PR. It was where if you're cuffed and click on a wirecutter, you can free yourself under a little over 10 seconds. 
