### PR TITLE
Mech replacement batteries keep 10% minimum charge+HUD fixes.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -867,9 +867,6 @@
 
 	src.go_out()
 	add_fingerprint(usr)
-
-	usr.hud_used.show_hud()
-	usr.hud_used.show_hud()
 	return
 
 /obj/mecha/container_resist()

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -1,3 +1,4 @@
+#define MINIMUM_CHARGE 10 //Minimum charge (in percent) replaced batteries will have, used to prevent eternal 0% power
 
 /obj/mecha/proc/take_damage(amount, type="brute")
 	if(amount)
@@ -247,7 +248,7 @@
 			clearInternalDamage(MECHA_INT_TEMP_CONTROL)
 			user << "<span class='notice'>You repair the damaged temperature controller.</span>"
 		else if(state==3 && src.cell)
-			powerleft = src.cell.charge/src.cell.maxcharge
+			powerleft = max(MINIMUM_CHARGE/100, src.cell.charge/src.cell.maxcharge)
 			src.cell.forceMove(src.loc)
 			src.cell = null
 			state = 4
@@ -344,3 +345,4 @@
 	take_damage(M.force, damtype)
 	add_logs(M.occupant, src, "attacked", M, "(INTENT: [uppertext(M.occupant.a_intent)]) (DAMTYPE: [uppertext(M.damtype)])")
 	return
+#undef MINIMUM_CHARGE

--- a/html/changelogs/Xthedark-MechBatteryFix_2.yml
+++ b/html/changelogs/Xthedark-MechBatteryFix_2.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Replacement batteries for Mechs keep at least 10% of their charge."


### PR DESCRIPTION
Issue #291 and #60
Replacement batteries will keep at least 10% charge (to prevent infinite 0% cell replacement).
Your HUD is no longer changed when exiting a mech.
