### PR TITLE
Communication Console Tweak

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -63,20 +63,16 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 		if("main")
 			src.state = STATE_DEFAULT
 		if("login")
-			var/mob/M = usr
-			var/obj/item/weapon/card/id/I = M.get_active_hand()
-			if (istype(I, /obj/item/device/pda))
-				var/obj/item/device/pda/pda = I
-				I = pda.id
-			if (I && istype(I))
-				if(src.check_access(I))
-					authenticated = 1
-					auth_id = "[I.registered_name] ([I.assignment])"
-					if((20 in I.access))
-						authenticated = 2
-				if(src.emagged)
+			var/mob/living/carbon/human/M = usr
+			var/obj/item/weapon/card/id/I = M.get_idcard()
+			if(src.allowed(M))
+				authenticated = 1
+				auth_id = "[I.registered_name] ([I.assignment])"
+				if((20 in I.access))
 					authenticated = 2
-					auth_id = "Unknown"
+			if(src.emagged)
+				authenticated = 2
+				auth_id = "Unknown"
 		if("logout")
 			authenticated = 0
 

--- a/html/changelogs/Super3222-ConsoleTweak.yml
+++ b/html/changelogs/Super3222-ConsoleTweak.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Nanotrasen has realized how frusturating it is to have to take off your ID to log into communication consoles. They've fixed that... now you don't have to take off your ID."


### PR DESCRIPTION
#27

You can now log into communication consoles without needing to hold your ID in your hand.
