### PR TITLE
Adds glasses warning to Thrall Darksight ability

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -233,7 +233,7 @@
 		if(istype(H.glasses, /obj/item/clothing/glasses/night/shadowling))
 			var/obj/item/clothing/glasses/night/shadowling/eyes = H.glasses
 			if (eyes.darkness_view == 0)
-				user << "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark.</span>"
+				user << "<span class='notice'>You shift the nerves in your eyes, allowing you to see in the dark. Any form of eye covering will hamper this ability.</span>"
 				eyes.darkness_view = 8
 			else
 				user << "<span class='notice'>You return your vision to normal.</span>"


### PR DESCRIPTION
Adds a warning to the thrall darksight ability, informing the user that glasses will block the ability. Will hopefully cut down on thrall ahelps.

If necessary I could instead make darksight work even with glasses on, but I would have to rewrite glasses code a bit and might run into problems.

Fixes #39 and #297.
