### PR TITLE
Syndiborg buff

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -114,7 +114,7 @@
 	return
 
 /obj/item/weapon/melee/energy/sword/cyborg
-	var/hitcost = 500
+	var/hitcost = 150
 
 /obj/item/weapon/melee/energy/sword/cyborg/attack(mob/M, var/mob/living/silicon/robot/R)
 	if(R.cell)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1149,11 +1149,12 @@
 
 /mob/living/silicon/robot/syndicate/New(loc)
 	..()
-	cell.maxcharge = 25000
-	cell.charge = 25000
+	cell = new /obj/item/weapon/stock_parts/cell/hyper(src)
 	radio = new /obj/item/device/radio/borg/syndicate(src)
 	module = new /obj/item/weapon/robot_module/syndicate(src)
 	laws = new /datum/ai_laws/syndicate_override()
+	var/obj/item/borg/upgrade/vtec/VTEC = new(src)
+	VTEC.action(src)
 
 /mob/living/silicon/robot/proc/notify_ai(notifytype, oldname, newname)
 	if(!connected_ai)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -250,7 +250,7 @@
 	modules += new /obj/item/weapon/gun/energy/printer(src)
 	modules += new /obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg(src)
 	modules += new /obj/item/weapon/tank/jetpack/carbondioxide(src)
-	modules += new /obj/item/weapon/crowbar(src)
+	modules += new /obj/item/weapon/crowbar/red(src)
 	modules += new /obj/item/weapon/card/emag(src)
 	modules += new /obj/item/weapon/pinpointer/operative(src)
 	emag = null

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -251,6 +251,7 @@
 	modules += new /obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg(src)
 	modules += new /obj/item/weapon/tank/jetpack/carbondioxide(src)
 	modules += new /obj/item/weapon/crowbar(src)
+	modules += new /obj/item/weapon/card/emag(src)
 	modules += new /obj/item/weapon/pinpointer/operative(src)
 	emag = null
 	fix_modules()

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -40,4 +40,5 @@
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	e_cost = 40
+	e_cost = 100
+	delay = 3

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -40,5 +40,5 @@
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	e_cost = 100
+	e_cost = 20
 	delay = 3

--- a/code/modules/projectiles/ammunition/special.dm
+++ b/code/modules/projectiles/ammunition/special.dm
@@ -40,4 +40,4 @@
 	projectile_type = /obj/item/projectile/bullet/midbullet3
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
-	e_cost = 20
+	e_cost = 40

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -189,31 +189,14 @@
 		else
 			recoil = initial(recoil)
 
-	if(burst_size > 1)
-		for(var/i = 1 to burst_size)
-			if(!issilicon(user))
-				if( i>1 && !(src in get_both_hands(user))) //for burst firing
-					break
-			if(chambered)
-				if(!chambered.fire(target, user, params, , suppressed))
-					shoot_with_empty_chamber(user)
-					break
-				else
-					if(get_dist(user, target) <= 1) //Making sure whether the target is in vicinity for the pointblank shot
-						shoot_live_shot(user, 1, target, message)
-					else
-						shoot_live_shot(user, 0, target, message)
-			else
-				shoot_with_empty_chamber(user)
+	for(var/i in 1 to burst_size)
+		if(!issilicon(user))
+			if( i>1 && !(src in get_both_hands(user))) //for burst firing
 				break
-			process_chamber()
-			update_icon()
-			sleep(fire_delay)
-	else
 		if(chambered)
 			if(!chambered.fire(target, user, params, , suppressed))
 				shoot_with_empty_chamber(user)
-				return
+				break
 			else
 				if(get_dist(user, target) <= 1) //Making sure whether the target is in vicinity for the pointblank shot
 					shoot_live_shot(user, 1, target, message)
@@ -221,12 +204,15 @@
 					shoot_live_shot(user, 0, target, message)
 		else
 			shoot_with_empty_chamber(user)
-			return
+			break
 		process_chamber()
 		update_icon()
-		semicd = 1
-		spawn(fire_delay)
-			semicd = 0
+		if(burst_size > 1)
+			sleep(fire_delay)
+		else
+			semicd = 1
+			spawn(fire_delay)
+				semicd = 0
 
 	if(user.hand)
 		user.update_inv_l_hand()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -37,7 +37,8 @@
 	return
 
 /obj/item/weapon/gun/energy/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, params)
-	newshot() //prepare a new shot
+	if(!chambered || !chambered.BB)
+		newshot() //prepare a new shot
 	..()
 
 /obj/item/weapon/gun/energy/can_shoot()
@@ -57,7 +58,10 @@
 	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...
 		var/obj/item/ammo_casing/energy/shot = chambered
 		power_supply.use(shot.e_cost)//... drain the power_supply cell
-	chambered = null //either way, released the prepared shot
+		chambered = null 
+		newshot()
+	else
+		chambered = null //either way, released the prepared shot
 	return
 
 /obj/item/weapon/gun/energy/proc/select_fire(mob/living/user)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -36,7 +36,6 @@
 	update_icon()
 	return
 
-
 /obj/item/weapon/gun/energy/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, params)
 	newshot() //prepare a new shot
 	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -288,22 +288,22 @@
 	icon = 'icons/obj/guns/projectile.dmi'
 	cell_type = "/obj/item/weapon/stock_parts/cell/secborg"
 	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
-	burst_size = 5
-	fire_delay = 3
+	burst_size = 3
 
 /obj/item/weapon/gun/energy/printer/update_icon()
 	return
 
-/obj/item/weapon/gun/energy/printer/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params)
-	if(isrobot(user))
-		var/mob/living/silicon/robot/R = user
+/obj/item/weapon/gun/energy/printer/newshot()
+	if(isrobot(src.loc))
+		var/mob/living/silicon/robot/R = src.loc
 		if(R && R.cell)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
-			if(R.cell.use(shot.e_cost*burst_size)) 		 //Take power from the borg...
-				power_supply.give(shot.e_cost*burst_size) //Give it to printer so it can fire
-				..()
+			if(R.cell.use(shot.e_cost))
+				power_supply.give(shot.e_cost)
+				chambered = shot
+				chambered.newshot()
 			else
-				user << "<span class='warning'>You don't have enough energy to fire this weapon!</span>"
+				usr << "<span class='warning'>You don't have enough energy to fire this weapon!</span>"
 	return
 
 /obj/item/weapon/gun/energy/temperature

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -288,35 +288,23 @@
 	icon = 'icons/obj/guns/projectile.dmi'
 	cell_type = "/obj/item/weapon/stock_parts/cell/secborg"
 	ammo_type = list(/obj/item/ammo_casing/energy/c3dbullet)
-	var/charge_tick = 0
-	var/recharge_time = 5
+	burst_size = 5
+	fire_delay = 3
 
 /obj/item/weapon/gun/energy/printer/update_icon()
 	return
 
-/obj/item/weapon/gun/energy/printer/New()
-	..()
-	SSobj.processing |= src
-
-
-/obj/item/weapon/gun/energy/printer/Destroy()
-	SSobj.processing.Remove(src)
-	..()
-
-/obj/item/weapon/gun/energy/printer/process()
-	charge_tick++
-	if(charge_tick < recharge_time) return 0
-	charge_tick = 0
-
-	if(!power_supply) return 0 //sanity
-	if(isrobot(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
+/obj/item/weapon/gun/energy/printer/process_fire(atom/target as mob|obj|turf, mob/living/user as mob|obj, message = 1, params)
+	if(isrobot(user))
+		var/mob/living/silicon/robot/R = user
 		if(R && R.cell)
 			var/obj/item/ammo_casing/energy/shot = ammo_type[select] //Necessary to find cost of shot
-			if(R.cell.use(shot.e_cost)) 		//Take power from the borg...
-				power_supply.give(shot.e_cost)	//...to recharge the shot
-
-	return 1
+			if(R.cell.use(shot.e_cost*burst_size)) 		 //Take power from the borg...
+				power_supply.give(shot.e_cost*burst_size) //Give it to printer so it can fire
+				..()
+			else
+				user << "<span class='warning'>You don't have enough energy to fire this weapon!</span>"
+	return
 
 /obj/item/weapon/gun/energy/temperature
 	name = "temperature gun"

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -27,7 +27,23 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher/multi
 	pin = /obj/item/device/firing_pin
 
-/obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg/attack_self()
+/obj/item/weapon/gun/projectile/revolver/grenadelauncher/cyborg/attack_self(mob/living/user)
+	if(magazine)
+		var/mob/living/silicon/robot/syndicate/R = user
+		var/ammo_count = get_ammo(0,0)
+		if(ammo_count < magazine.max_ammo && R && R.cell)
+			for(var/i in 1 to magazine.max_ammo-ammo_count)
+				user << "<span class='notice'>You start fabricating a shell, you will need to stay still for this.</span>"
+				if(do_after(user, 60, target = user))
+					if(R.cell.use(500))
+						var/shell_to_load = new magazine.ammo_type()
+						magazine.give_round(shell_to_load, 1)
+						if(!chambered.BB)
+							chamber_round()
+				else
+					break
+	else
+		user << "<span class='notice'>You should never see this message.</span>"
 	return
 
 /obj/item/weapon/gun/projectile/automatic/gyropistol

--- a/html/changelogs/Xthedark-SyndiborgBuff.yml
+++ b/html/changelogs/Xthedark-SyndiborgBuff.yml
@@ -8,6 +8,6 @@ changes:
   - rscadd: "The Syndicate have severely improved their Syndiborg models!"
   - rscadd: "Syndicate Cyborgs start with the VTEC upgrade installed."
   - rscadd: "Cryptographic Sequencer now comes added to Syndicate Cyborg equipment list."
-  - rscadd: "Syndicate Cyborg light machine gun fires 3 round bursts and does not need charging (can be fired as long as you have energy). Costs 300 energy per burst."
+  - rscadd: "Syndicate Cyborg light machine gun can now fire 1/3/5 round bursts recharges faster (1 bullet per 2 ticks instead of 5). Examining it now tells you how much ammo is in it's replicator."
   - rscadd: "Syndicate Cyborg grenade launcher can replicate grenades. To begin the process, click on the grenade launcher when it is equipped. Fabricates 1 shell every 6 seconds and you must stand still during the process."
   - tweak: "Cyborg energy sword costs 150 energy to use (down from 500)."

--- a/html/changelogs/Xthedark-SyndiborgBuff.yml
+++ b/html/changelogs/Xthedark-SyndiborgBuff.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: true
+
+changes: 
+  - rscadd: "The Syndicate have severely improved their Syndiborg models!"
+  - rscadd: "Syndicate Cyborgs start with the VTEC upgrade installed."
+  - rscadd: "Cryptographic Sequencer now comes added to Syndicate Cyborg equipment list."
+  - rscadd: "Syndicate Cyborg light machine gun fires 3 round bursts and does not need charging (can be fired as long as you have energy). Costs 300 energy per burst."
+  - rscadd: "Syndicate Cyborg grenade launcher can replicate grenades. To begin the process, click on the grenade launcher when it is equipped. Fabricates 1 shell every 6 seconds and you must stand still during the process."
+  - tweak: "Cyborg energy sword costs 150 energy to use (down from 500)."


### PR DESCRIPTION
Issue #271 

Syndiborgs now come with plethora of buffs:
1. LMG recharges every 2 ticks (instead of 5), supports firing modes of 1/3/5 rounds. Examining the Cyborg LMG now tells you how much ammo it has in it. Maximum capacity is 30 (not changed, just readily apparent now).
2. Grenade Launcher replicates 1 shot every 6 seconds when activated and standing still (500 energy per replicated shell);
3. Emag added (no energy usage);
4. Crowbar changed to red (no energy usage still);
5. Energy Sword cost down to 150 (from 500);
6. VTEC module comes added;

Flash is unchanged, still works the same way it did. 
As a sidenote, after this PR, energy weapons will support burst_size properly.

I expect this to make Syndicate Cyborgs completely broken.

**ANY ADDITIONAL COMMENTS/THINGS TO ADD WELCOME**
