### PR TITLE
Nuke Ops now actually have 5 minutes (instead of 2) to decide on War

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,5 +1,5 @@
 #define CHALLENGE_TC_PER_PLAYER 5.6
-#define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_TIME_LIMIT 4800 //8 minutes, which equates to 5 minutes after round start since round starts at 12:03 to actually give nukeops 5 minutes
 #define CHALLENGE_MIN_PLAYERS 25
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
@@ -23,7 +23,7 @@
 		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
 		return
 
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for your assault.", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew?<br>You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for declaring War.", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		user << "On second thought, the element of surprise isn't so bad after all."
 		return
@@ -34,11 +34,12 @@
 
 	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
 		S.challenge = TRUE
+		S.challenge_time = world.time
 
 	var/obj/item/device/radio/uplink/U = new(get_turf(user))
 	U.hidden_uplink.uplink_owner = "[user.key]"
 	U.hidden_uplink.uses = round(CHALLENGE_TC_PER_PLAYER*player_list.len)
-	config.shuttle_refuel_delay = max(config.shuttle_refuel_delay, CHALLENGE_SHUTTLE_DELAY)
+	config.shuttle_refuel_delay = max(config.shuttle_refuel_delay, CHALLENGE_SHUTTLE_DELAY+world.time) //Adds delay when item used
 	qdel(src)
 
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -23,7 +23,7 @@
 		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
 		return
 
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew?<br>You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for declaring War.", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for declaring War.", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		user << "On second thought, the element of surprise isn't so bad after all."
 		return

--- a/code/game/machinery/computer/syndicate_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_shuttle.dm
@@ -1,4 +1,4 @@
-#define SYNDICATE_CHALLENGE_TIMER 12000
+#define SYNDICATE_CHALLENGE_TIMER 12000 //20 minutes after declaration
 
 /obj/machinery/computer/shuttle/syndicate
 	name = "syndicate shuttle terminal"
@@ -8,11 +8,12 @@
 	shuttleId = "syndicate"
 	possible_destinations = "syndicate_away;syndicate_z5;syndicate_z3;syndicate_z4;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s"
 	var/challenge = FALSE
+	var/challenge_time = null
 
 /obj/machinery/computer/shuttle/syndicate/Topic(href, href_list)
 	if(href_list["move"])
-		if(challenge && world.time < SYNDICATE_CHALLENGE_TIMER)
-			usr << "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least [round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] more minutes to allow them to prepare.</span>"
+		if(challenge && (world.time < challenge_time + SYNDICATE_CHALLENGE_TIMER))
+			usr << "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least [round(((challenge_time + SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] more minutes to allow them to prepare.</span>"
 			return 0
 	..()
 	

--- a/html/changelogs/Xthedark-NukeOpChallengeTime.yml
+++ b/html/changelogs/Xthedark-NukeOpChallengeTime.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: true
+
+changes: 
+  - tweak: "Nuclear Operatives now actually get 5 minutes (instead of 2) to decide on the War option."


### PR DESCRIPTION
Title. Changed the time to make War from 5 minutes to 8, because round starts at 12:03 which caused ops to have only 2 minutes to make an announcement.
