### PR TITLE
Reduces PDA alert spam, especially in the case of fire alarms.

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -285,19 +285,19 @@
 	var/msg
 	switch(class)
 		if("Atmosphere")
-			if(!(alert_flags & PDA_ATMOS_ALERT))
+			if(!(alert_flags & PDA_ATMOS_ALERT) || (A in atmos_alerts))
 				return
 			atmos_alerts += A
 			if(alert_toggles & PDA_ATMOS_ALERT)
 				msg = "Alert: Atmos alarm in \the [A]"
 		if("Power")
-			if(!(alert_flags & PDA_POWER_ALERT))
+			if(!(alert_flags & PDA_POWER_ALERT) || (A in power_alerts))
 				return
 			power_alerts += A
 			if(alert_toggles & PDA_POWER_ALERT)
 				msg = "Alert: Power alarm in \the [A]"
 		if("Fire")
-			if(!(alert_flags & PDA_FIRE_ALERT))
+			if(!(alert_flags & PDA_FIRE_ALERT) || (A in fire_alerts))
 				return
 			fire_alerts += A
 			if(alert_toggles & PDA_FIRE_ALERT)

--- a/html/changelogs/Cruix-fire_alert_spam.yml
+++ b/html/changelogs/Cruix-fire_alert_spam.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "Stops PDA fire alert message spam."


### PR DESCRIPTION
Rooms with fires had a tendency to trigger fire alerts rapidly, which would spam ghosts and anyone near a PDA set to receive fire alerts. This would also fill the "view alerts" screen with the same area multiple times. This fixes the issue by making PDAs not accept any alerts if the alert's area is already stored in the PDA's alert buffer.
