### PR TITLE
Odysseus Improvements, Part 2.1 : Rearming Syringes

### DIFF
--- a/html/changelogs/Xthedark-Improve_Ody_2.yml
+++ b/html/changelogs/Xthedark-Improve_Ody_2.yml
@@ -1,0 +1,6 @@
+author: Xthedark
+
+delete-after: True
+
+changes: 
+  - rscadd: "Odysseus can now rearm it's syringes. Rearm is done in bulk (all or nothing) with 3 second per syringe, must stand still and costs 250 energy per syringe."


### PR DESCRIPTION
Yup, this is still not dead yet.

Syringes can be rearmed now:
- 3 seconds per syringe;
- Can only be done in bulk (all or nothing);
- 250 energy per syringe : at 10, you are looking at 12.5% energy of the standard 20k cell mechs get.
- Must stand still for entire duration;

All of the above are purely for balance. I'd like rearm to be instant or have Syringe Gun not have ammo but generate syringe when firing.
