### PR TITLE
Fixes Cyborgs not having Sensor Mode/Photography buttons

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -61,8 +61,8 @@
 	var/mob/living/silicon/robot/R = usr
 	R.control_headlamp()
 
-
 /datum/hud/proc/robot_hud(ui_style = 'icons/mob/screen_cyborg.dmi')
+	var/ui_style_ai = 'icons/mob/screen_ai.dmi' //need for AI-based HUD elements (Sec/MedHUD, Photography)
 	adding = list()
 	other = list()
 
@@ -103,18 +103,18 @@
 
 	using = new /obj/screen/ai/image_take()
 	using.screen_loc = ui_borg_camera
-	using.icon = ui_style
+	using.icon = ui_style_ai
 	adding += using
 
 	using = new /obj/screen/ai/image_view()
 	using.screen_loc = ui_borg_album
-	using.icon = ui_style
+	using.icon = ui_style_ai
 	adding += using
 
 //Sec/Med HUDs
 	using = new /obj/screen/ai/sensors()
 	using.screen_loc = ui_borg_sensor
-	using.icon = ui_style
+	using.icon = ui_style_ai
 	adding += using
 
 //Headlamp control

--- a/html/changelogs/xthedark-Borg_HUD.yml
+++ b/html/changelogs/xthedark-Borg_HUD.yml
@@ -1,0 +1,6 @@
+author: Xthedark
+
+delete-after: True
+
+changes: 
+  - bugfix: "Cyborgs got their Sensor Mode and Photography buttons back."


### PR DESCRIPTION
**Cause :** Sensor Mode/Photography are AI-based HUD elements and during robot HUD initialization, this was not respected (icons were looked in screen_robot.dmi instead of screen_ai.dmi).

**Fix :** Added a new ui_style_ai var that contains the path to screen_ai.dmi and that is used to create AI based elements in robot HUD.
