### PR TITLE
Disables editing of sound related variables unless admin has +SOUND.

### DIFF
--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -8,6 +8,7 @@ var/list/forbidden_varedit_object_types = list(
 var/list/VVlocked = list("vars", "client", "virus", "viruses", "cuffed", "last_eaten", "unlock_content", "step_x", "step_y", "force_ending")
 var/list/VVicon_edit_lock = list("icon", "icon_state", "overlays", "underlays")
 var/list/VVckey_edit = list("key", "ckey")
+var/list/VVsound_edit_lock = list("honksound", "hitsound") //this is to prevent admins circumventing need for +SOUND
 
 /*
 /client/proc/cmd_modify_object_variables(obj/O as obj|mob|turf|area in world)
@@ -390,11 +391,6 @@ var/list/VVckey_edit = list("key", "ckey")
 		usr << "<span class='danger'>You cannot edit ckeys on client objects.</span>"
 		return
 
-	if(param_var_name == "honksound")
-		usr << "<span class='danger'>Editing this variable is forbidden. Don't you even try, [usr.ckey]!"
-		message_admins("[key_name_admin(src)] tried to modify a banned variable. Shame on them!")
-		return
-
 	var/class
 	var/variable
 	var/var_value
@@ -410,6 +406,8 @@ var/list/VVckey_edit = list("key", "ckey")
 			if(!check_rights(R_SPAWN|R_DEBUG)) return
 		if(param_var_name in VVicon_edit_lock)
 			if(!check_rights(R_FUN|R_DEBUG)) return
+		if(param_var_name in VVsound_edit_lock)
+			if(!check_rights(R_SOUNDS)) return
 
 		variable = param_var_name
 
@@ -472,6 +470,8 @@ var/list/VVckey_edit = list("key", "ckey")
 			if(!check_rights(R_SPAWN|R_DEBUG)) return
 		if(variable in VVicon_edit_lock)
 			if(!check_rights(R_FUN|R_DEBUG)) return
+		if(variable in VVsound_edit_lock)
+			if(!check_rights(R_SOUNDS)) return
 
 	if(!autodetect_class)
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -390,6 +390,11 @@ var/list/VVckey_edit = list("key", "ckey")
 		usr << "<span class='danger'>You cannot edit ckeys on client objects.</span>"
 		return
 
+	if(param_var_name == "honksound")
+		usr << "<span class='danger'>Editing this variable is forbidden. Don't you even try, [usr.ckey]!"
+		message_admins("[key_name_admin(src)] tried to modify a banned variable. Shame on them!")
+		return
+
 	var/class
 	var/variable
 	var/var_value

--- a/html/changelogs/AsV9-sound-patch.yml
+++ b/html/changelogs/AsV9-sound-patch.yml
@@ -1,0 +1,6 @@
+author: AsV9
+
+delete-after: True
+
+changes: 
+  - bugfix: "Admins can no longer edit sound related variables if they do not have +SOUND."


### PR DESCRIPTION
There are probably more abusable variables but this has got to do for now.
