### PR TITLE
Ported /tg/'s slime person split

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -33,6 +33,7 @@
 	var/key
 	var/name				//replaces mob/var/original_name
 	var/mob/living/current
+	var/list/slime_bodies = list() //Keep a list of all our bodies
 	var/active = 0
 
 	var/memory

--- a/code/game/dna.dm
+++ b/code/game/dna.dm
@@ -30,12 +30,15 @@
 	if(new_holder && istype(new_holder))
 		holder = new_holder
 
-/datum/dna/proc/transfer_identity(mob/living/carbon/destination)
+/datum/dna/proc/transfer_identity(mob/living/carbon/destination, transfer_SE = 0)
 	if(check_dna_integrity(destination))
 		destination.dna.unique_enzymes = unique_enzymes
 		destination.dna.uni_identity = uni_identity
 		destination.dna.blood_type = blood_type
-		hardset_dna(destination, null, null, null, null, species)
+		if(transfer_SE)
+			hardset_dna(destination, null, struc_enzymes, null, null, species.type)
+		else
+			hardset_dna(destination, null, null, null, null, species.type)
 		destination.dna.features = features
 		destination.dna.real_name = real_name
 		destination.dna.mutations = mutations

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -366,13 +366,21 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	hair_color = "mutcolor"
 	hair_alpha = 150
 	ignored_by = list(/mob/living/simple_animal/slime)
+	burnmod = 0.5
+	coldmod = 2
+	heatmod = 0.5
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
 	var/recently_changed = 1
 
 /datum/species/slime/spec_life(mob/living/carbon/human/H)
+	if(H.stat == DEAD)
+		return
+
 	if(!H.reagents.get_reagent_amount("slimejelly"))
 		if(recently_changed)
+			var/datum/action/split_body/S = new
+			S.Grant(H)
 			H.reagents.add_reagent("slimejelly", 80)
 			recently_changed = 0
 		else
@@ -381,6 +389,10 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 			H << "<span class='danger'>You feel empty!</span>"
 
 	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
+		if(S.volume < 200)
+			if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+				H.reagents.add_reagent("slimejelly", 0.5)
+				H.nutrition -= 5
 		if(S.volume < 100)
 			if(H.nutrition >= NUTRITION_LEVEL_STARVING)
 				H.reagents.add_reagent("slimejelly", 0.5)
@@ -394,6 +406,103 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 /datum/species/slime/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == "slimejelly")
 		return 1
+
+/datum/action/split_body
+	name = "Split Body"
+	check_flags = AB_CHECK_ALIVE
+	action_type = AB_INNATE
+	button_icon_state = "blink"
+	background_icon_state = "bg_alien"
+
+/datum/action/split_body/CheckRemoval()
+	var/mob/living/carbon/human/H = owner
+	if(!ishuman(H) || !H.dna || !H.dna.species || H.dna.species.id != "slime")
+		return 1
+	return 0
+
+/datum/action/split_body/Activate()
+	var/mob/living/carbon/human/H = owner
+	H << "<span class='notice'>You focus intently on moving your body while standing perfectly still...</span>"
+	H.notransform = 1
+	for(var/datum/reagent/toxin/slimejelly/S in H.reagents.reagent_list)
+		if(S.volume >= 200)
+			var/mob/living/carbon/human/spare = new /mob/living/carbon/human(H.loc)
+			spare.underwear = "Nude"
+			H.dna.transfer_identity(spare, 1) //Transfer SE (second parameter) = 1
+			H.dna.features["mcolor"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
+			var/rand_num = rand(1,1000)
+			spare.real_name = "[spare.dna.real_name] [num2text(rand_num)]"
+			spare.name = "[spare.dna.real_name] [num2text(rand_num)]"
+			updateappearance(spare)
+			domutcheck(spare)
+			spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
+			S.volume = 80
+			H.notransform = 0
+			if(!H.mind.slime_bodies.len) //if this is our first time splitting add current body
+				H.mind.slime_bodies += H
+				var/datum/action/swap_body/callswap = new /datum/action/swap_body()
+				callswap.Grant(H)
+			var/datum/action/swap_body/callswap = new /datum/action/swap_body()
+			H.mind.slime_bodies += spare
+			callswap.Grant(spare)
+			/*
+			var/datum/action/swap_body/callforward = new /datum/action/swap_body()
+			var/datum/action/swap_body/callback = new /datum/action/swap_body()
+			callforward.body = spare
+			callforward.Grant(H)
+			callback.body = H
+			callback.Grant(spare)
+			*/
+			H.mind.transfer_to(spare)
+			spare << "<span class='notice'>...and after a moment of disorentation, you're besides yourself!</span>"
+			return
+
+	H << "<span class='warning'>...but there is not enough of you to go around! You must attain more mass to split!</span>"
+	H.notransform = 0
+
+/datum/action/swap_body
+	name = "Swap Body"
+	check_flags = AB_CHECK_ALIVE
+	action_type = AB_INNATE
+	button_icon_state = "mindswap"
+	background_icon_state = "bg_alien"
+	//var/mob/living/carbon/human/body
+	//var/list/slime_bodies = list() //Keep a list of all our bodies
+
+/datum/action/swap_body/CheckRemoval()
+	var/mob/living/carbon/human/H = owner
+	if(!ishuman(H) || !H.dna || !H.dna.species || H.dna.species.id != "slime")
+		return 1
+	return 0
+
+/datum/action/swap_body/Activate()
+	var/list/temp_body_list = list()
+
+	for(var/slime_body in owner.mind.slime_bodies)
+		var/mob/living/carbon/human/body = slime_body
+		if(!body || !istype(body) || !body.dna || !body.dna.species || body.dna.species.id != "slime" || body.stat == DEAD || qdeleted(body))
+			owner.mind.slime_bodies -= body
+			continue
+		temp_body_list += body
+
+	if(!owner.mind.slime_bodies.len) //THEY ARE ALL DEAD
+		owner << "<span class='warning'>Something is wrong, you cannot sense your other bodies!</span>"
+		Remove(owner)
+		return
+
+	//HE'S STILL ALIVE
+	var/body_name = input(owner, "Select the body you want to move into", "List of active bodies") as null|anything in temp_body_list
+
+	if(!body_name)
+		return
+
+	var/mob/living/carbon/human/selected_body = body_name
+
+	if(!selected_body)
+		return
+
+	owner.mind.transfer_to(selected_body)
+
 /*
  JELLYPEOPLE
 */

--- a/html/changelogs/xthedark-TGSlimePersonPort.yml
+++ b/html/changelogs/xthedark-TGSlimePersonPort.yml
@@ -1,0 +1,6 @@
+author: Xthedark
+
+delete-after: True
+
+changes: 
+  - rscadd: "Ported /tg/ Slime Person split ability by Incoming5643. Slime People can now split, provided enough Slime Jelly (200), which they gain passively. You gain up to 100 if you are not Starving and up to 200 if you are above Well Fed. Slime Jelly production MASSIVELY burns your nutrition."


### PR DESCRIPTION
Issue #374 (linked to /tg/ pull)
Ported over TG Slime Person Split ability by @Incoming5643.

**Damage:**
- 50% heat/burn damage resist;
- 2x cold damage multiplier;

**Splitting:**
- Requires 200 Slime Jelly in your body to split. When you are at 200+, 5% chance every tick for a "You are feeling bloated" message to let you know you are ready to split. Alternatively, go to medbay, the sleepers will show how much Jelly is in your body.
- Gain up to 200, if you stay above Well Fed;
- You gain up to 100, if you stay above Starving;
- During Slime Jelly creation, you burn nutrition MASSIVELY (EDIT: 2.5+0.1 nutrition per tick, instead of 0.1)

After splitting, you gain ability to Swap Bodies. I've made a few improvements and now you can select any eligible body to transfer yourself to (instead of strictly the one you split into/out of), no limits on range or anything. Splitting causes your other body to gain a random number suffix (1-1000) for identification purposes. When you press Swap Body, you get an Input prompt to select eligible body from list of names. Cannot swap into/out of unconscious bodies (too much damage or sleeping).

Enjoy.

**EDIT: Additional changes**
Nutrition consumption decreased to 2.5 (from 5), ported from latest /tg/ version.
5% chance of message that you are bloated when 200+ Slime Jelly, ported from /tg/ version.
Unconsciousness checks everywhere. Unconscious bodies and your current body are not shown in the selection panel, so you can quickswap without fear of ending up in the same body.
