### PR TITLE
isnull is Required!

### DIFF
--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -40,7 +40,7 @@ var/jobban_keylist[0]		//to store the keys & ranks
 /proc/jobban_list_for_mob(mob/M)
 	if (!M) return 0
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT job FROM [format_table_name("ban")] WHERE ckey = '[get_ckey(M)]' AND job = '[rank]' AND (bantype = 'JOB_PERMABAN' OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
+	var/DBQuery/query = dbcon.NewQuery("SELECT job FROM [format_table_name("ban")] WHERE ckey = '[get_ckey(M)]' AND (bantype = 'JOB_PERMABAN' OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
 	query.Execute()
 
 	var/list/ckey_job_bans = list()

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -19,7 +19,7 @@ var/jobban_keylist[0]		//to store the keys & ranks
 	/*var/list/tempList = jobban_list_for_mob(M)
 	return jobban_job_in_list(tempList, rank)*/
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT job FROM [format_table_name("ban")] WHERE ckey = '[get_ckey(M)]' AND job = '[rank]' AND (bantype = 'JOB_PERMABAN' OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND unbanned != 1")
+	var/DBQuery/query = dbcon.NewQuery("SELECT job FROM [format_table_name("ban")] WHERE ckey = '[get_ckey(M)]' AND job = '[rank]' AND (bantype = 'JOB_PERMABAN' OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
 	query.Execute()
 
 	if(query.NextRow())
@@ -40,7 +40,7 @@ var/jobban_keylist[0]		//to store the keys & ranks
 /proc/jobban_list_for_mob(mob/M)
 	if (!M) return 0
 
-	var/DBQuery/query = dbcon.NewQuery("SELECT job FROM [format_table_name("ban")] WHERE ckey = '[get_ckey(M)]' AND ((bantype = 'JOB_PERMABAN' AND isnull(unbanned)) OR (bantype = 'JOB_TEMPBAN' AND (isnull(unbanned) OR expiration_time > Now())))")
+	var/DBQuery/query = dbcon.NewQuery("SELECT job FROM [format_table_name("ban")] WHERE ckey = '[get_ckey(M)]' AND job = '[rank]' AND (bantype = 'JOB_PERMABAN' OR (bantype = 'JOB_TEMPBAN' AND expiration_time > Now())) AND isnull(unbanned)")
 	query.Execute()
 
 	var/list/ckey_job_bans = list()


### PR DESCRIPTION
Bans not fixing. Coder chat assuming its something to do with unbanned != 1. In SQL NULL cannot be compared to other objects such as 1. This may be causing the connection from the server to the database to be killed. This is all in theory.

Theres a reason why isnull exists.
