### PR TITLE
Ported several /tg/ chems and balance changes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -78,6 +78,8 @@
 	shock_damage *= siemens_coeff
 	if(shock_damage<1 && !override)
 		return 0
+	if(reagents.has_reagent("teslium"))
+		shock_damage *= 1.5
 	take_overall_damage(0,shock_damage)
 	//src.burn_skin(shock_damage)
 	//src.adjustFireLoss(shock_damage) //burn_skin will do this for us

--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -121,6 +121,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				blood_max += 2
 		if(bleedsuppress)
 			blood_max = 0
+		if(reagents.has_reagent("heparin") && getBruteLoss()) //Heparin is a powerful toxin that causes bleeding
+			blood_max += 3
 		drip(blood_max)
 
 //Makes a blood drop, leaking amt units of blood from the mob

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -305,16 +305,22 @@
 
 	if(bleedsuppress)
 		msg += "[t_He] [t_is] bandaged with something.\n"
-	else if(blood_max)
-		switch (blood_max)
-			if (0.05 to 1)
-				msg += "[t_He] [t_is] bleeding very slightly.\n"
-			if (1.5 to 3)
-				msg += "<B>[t_He] [t_is] bleeding significantly!</B>\n"
-			if (4 to 6)
-				msg += "<B>[t_He] [t_is] bleeding severely!</B>\n"
-			if (6 to INFINITY)
-				msg += "<B>[t_He] [t_is] bleeding out quickly!</B>\n"
+	if(blood_max)
+		if(reagents.has_reagent("heparin"))
+			msg += "<b>[t_He] [t_is] bleeding uncontrollably!</b>\n"
+		else
+			switch (blood_max)
+				if (0.05 to 1)
+					msg += "[t_He] [t_is] bleeding very slightly.\n"
+				if (1.5 to 3)
+					msg += "<B>[t_He] [t_is] bleeding significantly!</B>\n"
+				if (4 to 6)
+					msg += "<B>[t_He] [t_is] bleeding severely!</B>\n"
+				if (6 to INFINITY)
+					msg += "<B>[t_He] [t_is] bleeding out quickly!</B>\n"
+
+	if(reagents.has_reagent("teslium"))
+		msg += "[t_He] is emitting a gentle blue glow!\n"
 
 	msg += "</span>"
 

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -16,7 +16,7 @@
 /datum/reagent/medicine/leporazine
 	name = "Leporazine"
 	id = "leporazine"
-	description = "Leporazine can be use to stabilize an individuals body temperature."
+	description = "Leporazine will effectively regulate a patient's body temperature, ensuring it never leaves safe levels."
 	color = "#C8A5DC" // rgb: 200, 165, 220
 
 /datum/reagent/medicine/leporazine/on_mob_life(mob/living/M)
@@ -68,12 +68,12 @@
 /datum/reagent/medicine/adminordrazine/nanites
 	name = "Nanites"
 	id = "nanites"
-	description = "Tiny machines capable of rapid cellular regeneration."
+	description = "Tiny nanomachines capable of rapid cellular regeneration."
 
 /datum/reagent/medicine/synaptizine
 	name = "Synaptizine"
 	id = "synaptizine"
-	description = "Synaptizine is used to treat various diseases."
+	description = "Increases resistance to stuns as well as reducing drowsiness and hallucinations."
 	color = "#C8A5DC" // rgb: 200, 165, 220
 
 /datum/reagent/medicine/synaptizine/on_mob_life(mob/living/M)
@@ -84,14 +84,14 @@
 	if(holder.has_reagent("mindbreaker"))
 		holder.remove_reagent("mindbreaker", 5)
 	M.hallucination = max(0, M.hallucination - 10)
-	if(prob(60))
+	if(prob(30))
 		M.adjustToxLoss(1)
 	..()
 	return
 /datum/reagent/medicine/inacusiate
 	name = "Inacusiate"
 	id = "inacusiate"
-	description = "Heals ear damage."
+	description = "Instantly restores all hearing to the patient, but does not cure deafness."
 	color = "#6600FF" // rgb: 100, 165, 255
 
 /datum/reagent/medicine/inacusiate/on_mob_life(mob/living/M)
@@ -102,7 +102,7 @@
 /datum/reagent/medicine/cryoxadone
 	name = "Cryoxadone"
 	id = "cryoxadone"
-	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the targets body temperature must be under 170K for it to metabolise correctly."
+	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the patient's body temperature must be under 170K for it to metabolise correctly."
 	color = "#0000C8"
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/M)
@@ -113,7 +113,6 @@
 		M.adjustFireLoss(-2)
 		M.adjustToxLoss(-2)
 		M.status_flags &= ~DISFIGURED
-
 	..()
 	return
 
@@ -123,21 +122,19 @@
 	description = "A powder derived from fish toxin, this substance can effectively treat cellular damage in humanoids, though excessive consumption has side effects."
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
+	overdose_threshold = 30
 
 /datum/reagent/medicine/rezadone/on_mob_life(mob/living/M)
-	switch(current_cycle)
-		if(1 to 15)
-			M.adjustCloneLoss(-1)
-			M.heal_organ_damage(1,1)
-		if(15 to 35)
-			M.adjustCloneLoss(-2)
-			M.heal_organ_damage(2,1)
-			M.status_flags &= ~DISFIGURED
-		if(35 to INFINITY)
-			M.adjustToxLoss(1)
-			M.Dizzy(5)
-			M.Jitter(5)
+	M.setCloneLoss(0) //Rezadone is almost never used in favor of cryoxadone. Hopefully this will change that.
+	M.heal_organ_damage(1,1)
+	M.status_flags &= ~DISFIGURED
+	..()
+	return
 
+/datum/reagent/medicine/rezadone/overdose_process(mob/living/M)
+	M.adjustToxLoss(1)
+	M.Dizzy(5)
+	M.Jitter(5)
 	..()
 	return
 
@@ -159,45 +156,68 @@
 /datum/reagent/medicine/silver_sulfadiazine
 	name = "Silver Sulfadiazine"
 	id = "silver_sulfadiazine"
-	description = "On touch, quickly heals burn damage. Basic anti-burn healing drug. On ingestion, deals minor toxin damage."
+	description = "If used in touch-based applications, immediately restores burn wounds as well as restoring more over time. If ingested through other means, deals minor toxin damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 
 /datum/reagent/medicine/silver_sulfadiazine/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
-		if(method == PATCH)
-			M.adjustFireLoss(-reac_volume/2.5)
-			if(show_message)
-				M << "<span class='notice'>You feel your burns healing!</span>"
-			M.emote("scream")
-		if(method == INGEST)
+		if(method in list(INGEST, VAPOR))
 			M.adjustToxLoss(0.5*reac_volume/1.5)
 			if(show_message)
-				M << "<span class='notice'>You probably shouldn't have eaten that. Maybe you should of splashed it on, or applied a patch?</span>"
+				M << "<span class='warning'>You don't feel so good...</span>"
+		else if(M.getFireLoss())
+			M.adjustFireLoss(-reac_volume/2.5)
+			if(show_message)
+				M << "<span class='notice'>You feel your burns healing! It stings like hell!</span>"
+			M.emote("scream")
 	..()
 
 /datum/reagent/medicine/silver_sulfadiazine/on_mob_life(mob/living/M)
 	M.adjustFireLoss(-2*REM)
 	..()
 
+/datum/reagent/medicine/oxandrolone
+	name = "Oxandrolone"
+	id = "oxandrolone"
+	description = "Stimulates the healing of severe burns. Extremely rapidly heals severe burns and slowly heals minor ones. Overdose will worsen existing burns."
+	reagent_state = LIQUID
+	color = "#f7ffa5"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 25
+
+/datum/reagent/medicine/oxandrolone/on_mob_life(mob/living/M)
+	if(M.getFireLoss() > 50)
+		M.adjustFireLoss(-4*REM) //Twice as effective as silver sulfadiazine for severe burns
+	else
+		M.adjustFireLoss(-0.5*REM) //But only a quarter as effective for more minor ones
+	..()
+	return
+
+/datum/reagent/medicine/oxandrolone/overdose_process(mob/living/M)
+	if(M.getFireLoss()) //It only makes existing burns worse
+		M.adjustFireLoss(4.5*REM) // it's going to be healing either 4 or 0.5
+	..()
+	return
+
 /datum/reagent/medicine/styptic_powder
 	name = "Styptic Powder"
 	id = "styptic_powder"
-	description = "On touch, quickly heals brute damage. Basic anti-brute healing drug. On ingestion, deals minor toxin damage."
+	description = "If used in touch-based applications, immediately restores bruising as well as restoring more over time. If ingested through other means, deals minor toxin damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 
 /datum/reagent/medicine/styptic_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
-		if(method == PATCH)
-			M.adjustBruteLoss(-reac_volume/2.5)
-			if(show_message)
-				M << "<span class='notice'>You feel your wounds knitting back together!</span>"
-			M.emote("scream")
-		if(method == INGEST)
+		if(method in list(INGEST, VAPOR))
 			M.adjustToxLoss(0.5*reac_volume/1.5)
 			if(show_message)
-				M << "<span class='notice'>You feel kind of ill. Maybe you ate a medicine you shouldn't have?</span>"
+				M << "<span class='warning'>You don't feel so good...</span>"
+		else if(M.getFireLoss())
+			M.adjustBruteLoss(-reac_volume/2.5)
+			if(show_message)
+				M << "<span class='notice'>You feel your bruises healing! It stings like hell!</span>"
+			M.emote("scream")
 	..()
 
 
@@ -222,7 +242,7 @@
 /datum/reagent/medicine/mine_salve
 	name = "Miner's Salve"
 	id = "mine_salve"
-	description = "Slowly heals burn and brute damage, and causes subject to believe they are fully healed."
+	description = "A powerful painkiller. Restores bruising and burns in addition to making the patient believe they are fully healed."
 	reagent_state = LIQUID
 	color = "#6D6374"
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
@@ -236,16 +256,15 @@
 	..()
 
 /datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
-	if(iscarbon(M))
-		if(method == TOUCH)
+	if(iscarbon(M) && M.stat != DEAD)
+		if(method in list(INGEST, VAPOR))
+			M.Stun(4)
+			M.Weaken(4)
 			if(show_message)
-				M << "<span class='notice'>You feel your wounds knitting back together!</span>"
-			method = VAPOR //so it's correctly absorbed in reagent/reaction_mob()
-		if(method == INGEST)
+				M << "<span class='warning'>Your stomach agonizingly cramps!</span>"
+		else
 			if(show_message)
-				M << "<span class='notice'>That tasted horrible.</span>"
-			M.AdjustStunned(2)
-			M.AdjustWeakened(2)
+				M << "<span class='notice'>You feel your wounds fade away to nothing!</span>" //It's a painkiller, after all
 	..()
 
 /datum/reagent/medicine/mine_salve/on_mob_delete(mob/living/M)
@@ -263,11 +282,11 @@
 
 /datum/reagent/medicine/synthflesh/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
-		if(method == PATCH)
-			M.adjustBruteLoss(-1.5*reac_volume/2.5)
-			M.adjustFireLoss(-1.5*reac_volume/2.5)
+		if(method in list(PATCH, TOUCH))
+			M.adjustBruteLoss(-1.5 * reac_volume/2.5)
+			M.adjustFireLoss(-1.5 * reac_volume/2.5)
 			if(show_message)
-				M << "<span class='notice'>You feel your burns healing and your flesh knitting together!</span>"
+				M << "<span class='notice'>You feel your burns and bruises healing! It stings like hell!</span>"
 	..()
 
 
@@ -357,8 +376,6 @@
 	if(M.radiation > 0)
 		M.radiation -= 4
 	M.adjustToxLoss(-2*REM)
-	if(prob(33))
-		M.adjustBruteLoss(0.5*REM)
 	if(M.radiation < 0)
 		M.radiation = 0
 	for(var/datum/reagent/R in M.reagents.reagent_list)
@@ -370,7 +387,7 @@
 /datum/reagent/medicine/sal_acid
 	name = "Salicyclic Acid"
 	id = "sal_acid"
-	description = "If you have less than 50 brute damage, it heals 0.25 unit. If overdosed it will deal 0.5 brute damage if the patient has less than 50 brute damage already."
+	description = "Very slowly restores low bruising. Primarily used as an ingredient in other medicines. Overdose causes slight bruising."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -391,7 +408,7 @@
 /datum/reagent/medicine/salbutamol
 	name = "Salbutamol"
 	id = "salbutamol"
-	description = "Quickly heals oxygen damage while slowing down suffocation. Great for stabilizing critical patients!"
+	description = "Rapidly restores oxygen deprivation as well as preventing more of it to an extent."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -406,7 +423,7 @@
 /datum/reagent/medicine/perfluorodecalin
 	name = "Perfluorodecalin"
 	id = "perfluorodecalin"
-	description = "Heals suffocation damage so quickly that you could have a spacewalk, but it mutes your voice. Has a 33% chance of healing brute and burn damage per cycle as well."
+	description = "Extremely rapidly restores oxygen deprivation, but inhibits speech. May also heal small amounts of bruising and burns."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -423,7 +440,7 @@
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"
 	id = "ephedrine"
-	description = "Reduces stun times, increases run speed. If overdosed it will deal toxin and oxyloss damage."
+	description = "Increases stun resistance and movement speed. Overdose deals toxin damage and inhibits breathing."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -474,23 +491,23 @@
 /datum/reagent/medicine/diphenhydramine
 	name = "Diphenhydramine"
 	id = "diphenhydramine"
-	description = "Purges body of lethal Histamine and reduces jitteriness while causing minor drowsiness."
+	description = "Rapidly purges the body of Histamine and reduces jitteriness. Slight chance of causing drowsiness."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/diphenhydramine/on_mob_life(mob/living/M)
-	if(prob(50))
+	if(prob(10))
 		M.drowsyness += 1
 	M.jitteriness -= 1
-	M.reagents.remove_reagent("histamine",1.5)
+	M.reagents.remove_reagent("histamine",3)
 	..()
 	return
 
 /datum/reagent/medicine/morphine
 	name = "Morphine"
 	id = "morphine"
-	description = "Will allow you to ignore slowdown from equipment and damage. Will eventually knock you out if you take too much. If overdosed it will cause jitteriness, dizziness, force the victim to drop items in their hands and eventually deal toxin damage."
+	description = "A painkiller that allows the patient to move at full speed even in bulky objects. Causes drowsiness and eventually unconsciousness in high doses. Overdose will cause a variety of effects, ranging from minor to lethal."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -500,8 +517,12 @@
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/M)
 	M.status_flags |= IGNORESLOWDOWN
-	if(current_cycle >= 12)
+	if(current_cycle == 11)
+		M << "<span class='warning'>You start to feel tired...</span>"
+	if(current_cycle >= 24)
 		M.sleeping += 1
+	else if(current_cycle >= 12)
+		M.drowsyness += 1
 	..()
 	return
 
@@ -558,43 +579,50 @@
 /datum/reagent/medicine/oculine
 	name = "Oculine"
 	id = "oculine"
-	description = "Cures blindness and heals eye damage over time."
+	description = "Quickly restores eye damage, cures nearsightedness, and has a chance to restore vision to the blind."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/oculine/on_mob_life(mob/living/M)
-	if(M.eye_blind > 0 && current_cycle > 20)
-		if(prob(30))
-			M.eye_blind = 0
-		else if(prob(80))
-			M.eye_blind = 0
-			M.eye_blurry = 1
-		if(M.eye_blurry > 0)
-			if(prob(80))
-				M.eye_blurry = 0
+	if(M.disabilities & BLIND)
+		if(prob(20))
+			M << "<span class='warning'>Your vision slowly returns...</span>"
+			M.disabilities &= ~BLIND
+			M.disabilities &= NEARSIGHT
+			M.eye_blurry = 35
+
+	else if(M.disabilities & NEARSIGHT)
+		M << "<span class='warning'>The blackness in your peripheral vision fades.</span>"
+		M.disabilities &= ~NEARSIGHT
+		M.eye_blurry = 10
+
+	else if(M.eye_blind || M.eye_blurry)
+		M.eye_blind = 0
+		M.eye_blurry = 0
+
+	else if(M.eye_stat > 0)
+		M.eye_stat -= 1
+		M.eye_stat = Clamp(M.eye_stat, 0, INFINITY)
 	..()
 	return
 
 /datum/reagent/medicine/atropine
 	name = "Atropine"
 	id = "atropine"
-	description = "If patients health is below -25 it will heal 1.5 brute and burn damage per cycle, as well as stop any oxyloss. Good for stabilising critical patients."
+	description = "If a patient is in critical condition, rapidly heals all damage types as well as regulating oxygen in the body. Excellent for stabilizing wounded patients."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 35
 
 /datum/reagent/medicine/atropine/on_mob_life(mob/living/M)
-	if(M.health > -60)
-		M.adjustToxLoss(0.5*REM)
-	if(M.health < -25)
-		M.adjustBruteLoss(-1.5*REM)
-		M.adjustFireLoss(-1.5*REM)
-	if(M.oxyloss > 65)
-		M.setOxyLoss(65)
-	if(M.losebreath > 5)
-		M.losebreath = 5
+	if(M.health < 0)
+		M.adjustToxLoss(-2*REM)
+		M.adjustBruteLoss(-2*REM)
+		M.adjustFireLoss(-2*REM)
+		M.adjustOxyLoss(-5*REM)
+	M.losebreath = 0
 	if(prob(20))
 		M.Dizzy(5)
 		M.Jitter(5)
@@ -611,14 +639,14 @@
 /datum/reagent/medicine/epinephrine
 	name = "Epinephrine"
 	id = "epinephrine"
-	description = "Reduces most of the knockout/stun effects, minor stamina regeneration buff. Attempts to stop you taking too much oxygen damage. If the patient is in low to severe crit, heals toxins, brute, and burn very effectively. Will not heal patients who are almost dead. If overdosed will stun and deal toxin damage"
+	description = "Minor boost to stun resistance. Slowly heals damage if a patient is in critical condition, as well as regulating oxygen loss. Overdose causes weakness and toxin damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 
 /datum/reagent/medicine/epinephrine/on_mob_life(mob/living/M)
-	if(M.health < -10 && M.health > -65)
+	if(M.health < 0)
 		M.adjustToxLoss(-0.5*REM)
 		M.adjustBruteLoss(-0.5*REM)
 		M.adjustFireLoss(-0.5*REM)
@@ -648,7 +676,7 @@
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	id = "strange_reagent"
-	description = "A miracle drug that can bring a dead body back to life! If the corpse has suffered too much damage, however, no change will occur to the body. If used on a living person it will deal Brute and Burn damage."
+	description = "A miracle drug capable of bringing the dead back to life. Only functions if the target has less than 100 brute and burn damage (independent of one another), and causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -685,7 +713,7 @@
 /datum/reagent/medicine/mannitol
 	name = "Mannitol"
 	id = "mannitol"
-	description = "Heals brain damage effectively. Use it in cyro tubes alongside Cryoxadone."
+	description = "Efficiently restores brain damage."
 	color = "#C8A5DC"
 
 /datum/reagent/medicine/mannitol/on_mob_life(mob/living/M)
@@ -696,7 +724,7 @@
 /datum/reagent/medicine/mutadone
 	name = "Mutadone"
 	id = "mutadone"
-	description = "Heals your genetic defects."
+	description = "Removes jitteriness and restores genetic defects."
 	color = "#C8A5DC"
 
 /datum/reagent/medicine/mutadone/on_mob_life(mob/living/carbon/human/M)
@@ -709,7 +737,7 @@
 /datum/reagent/medicine/antihol
 	name = "Antihol"
 	id = "antihol"
-	description = "Helps remove Alcohol from someone's body, as well as eliminating its side effects."
+	description = "Purges alcoholic substance from the patient's body and eliminates its side effects."
 	color = "#C8A5DC"
 
 /datum/reagent/medicine/antihol/on_mob_life(mob/living/M)
@@ -764,11 +792,12 @@
 	M.reagents.remove_reagent("sugar", 3)
 	..()
 	return
+
  // TREK CHEMS
 datum/reagent/medicine/bicaridine
 	name = "Bicaridine"
 	id = "bicaridine"
-	description = "Heals brute damage."
+	description = "Restores bruising. Overdose causes it instead."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
@@ -786,7 +815,7 @@ datum/reagent/medicine/bicaridine/overdose_process(mob/living/M)
 datum/reagent/medicine/dexalin
 	name = "Dexalin"
 	id = "dexalin"
-	description = "Heals oxygen damage."
+	description = "Restores oxygen loss. Overdose causes it instead."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
@@ -804,7 +833,7 @@ datum/reagent/medicine/dexalin/overdose_process(mob/living/M)
 datum/reagent/medicine/kelotane
 	name = "Kelotane"
 	id = "kelotane"
-	description = "Heals burn damage."
+	description = "Restores fire damage. Overdose causes it instead."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
@@ -823,7 +852,7 @@ datum/reagent/medicine/kelotane/overdose_process(mob/living/M)
 datum/reagent/medicine/antitoxin
 	name = "Anti-toxin"
 	id = "antitoxin"
-	description = "Heals toxin damage."
+	description = "Heals toxin damage and removes toxins in the bloodstream. Overdose causes toxin damage."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
@@ -845,7 +874,7 @@ datum/reagent/medicine/antitoxin/overdose_process(mob/living/M)
 datum/reagent/medicine/inaprovaline
 	name = "Inaprovaline"
 	id = "inaprovaline"
-	description = "Stabilizes critical condition patients."
+	description = "Stabilizes the breathing of patients. Good for those in critical condition."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 
@@ -858,7 +887,7 @@ datum/reagent/medicine/inaprovaline/on_mob_life(mob/living/M)
 datum/reagent/medicine/tricordrazine
 	name = "Tricordrazine"
 	id = "tricordrazine"
-	description = "Chance to heal 1 of each damage type."
+	description = "Has a high chance to heal all types of damage. Overdose instead causes it."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	overdose_threshold = 30
@@ -877,5 +906,27 @@ datum/reagent/medicine/tricordrazine/overdose_process(mob/living/M)
 	M.adjustOxyLoss(2*REM)
 	M.adjustBruteLoss(2*REM)
 	M.adjustFireLoss(2*REM)
+	..()
+	return
+
+/datum/reagent/medicine/haloperidol
+	name = "Haloperidol"
+	id = "haloperidol"
+	description = "Increases depletion rates for most stimulating/hallucinogenic drugs. Reduces druggy effects and jitteriness. Severe stamina regeneration penalty, causes drowsiness. Small chance of brain damage."
+	reagent_state = LIQUID
+	color = "#27870a"
+	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/haloperidol/on_mob_life(mob/living/M)
+	for(var/datum/reagent/drug/R in M.reagents.reagent_list)
+		M.reagents.remove_reagent(R.id,5)
+	M.drowsyness += 2
+	if(M.jitteriness >= 3)
+		M.jitteriness -= 3
+	if (M.hallucination >= 5)
+		M.hallucination -= 5
+	if(prob(20))
+		M.adjustBrainLoss(1*REM)
+	M.adjustStaminaLoss(2.5*REM)
 	..()
 	return

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -19,7 +19,7 @@
 	id = "amatoxin"
 	description = "A powerful poison derived from certain species of mushroom."
 	color = "#792300" // rgb: 121, 35, 0
-	toxpwr = 1
+	toxpwr = 2.5
 
 /datum/reagent/toxin/mutagen
 	name = "Unstable mutagen"
@@ -88,15 +88,16 @@
 /datum/reagent/toxin/lexorin
 	name = "Lexorin"
 	id = "lexorin"
-	description = "Lexorin temporarily stops respiration. Causes tissue damage."
+	description = "A powerful poison used to stop respiration."
 	color = "#C8A5DC" // rgb: 200, 165, 220
 	toxpwr = 0
 
 /datum/reagent/toxin/lexorin/on_mob_life(mob/living/M)
 	if(M.stat != DEAD)
-		if(prob(33))
-			M.take_organ_damage(1*REM, 0)
-		M.adjustOxyLoss(3)
+		M.adjustOxyLoss(5)
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
+			C.losebreath += 2
 		if(prob(20))
 			M.emote("gasp")
 	..()
@@ -222,7 +223,7 @@
 /datum/reagent/toxin/spore
 	name = "Spore Toxin"
 	id = "spore"
-	description = "A toxic spore cloud which blocks vision when ingested."
+	description = "A natural toxin produced by blob spores that inhibits vision when ingested."
 	color = "#9ACD32"
 	toxpwr = 0.5
 
@@ -236,7 +237,7 @@
 /datum/reagent/toxin/spore_burning
 	name = "Burning Spore Toxin"
 	id = "spore_burning"
-	description = "A burning spore cloud."
+	description = "A natural toxin produced by blob spores that induces combustion in its victim."
 	color = "#9ACD32"
 	toxpwr = 0.5
 
@@ -248,7 +249,7 @@
 /datum/reagent/toxin/chloralhydrate
 	name = "Chloral Hydrate"
 	id = "chloralhydrate"
-	description = "A powerful sedative."
+	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
 	reagent_state = SOLID
 	color = "#000067" // rgb: 0, 0, 103
 	toxpwr = 0
@@ -270,7 +271,7 @@
 /datum/reagent/toxin/beer2	//disguised as normal beer for use by emagged brobots
 	name = "Beer"
 	id = "beer2"
-	description = "An alcoholic beverage made from malted grains, hops, yeast, and water."
+	description = "A specially-engineered sedative disguised as beer. It induces instant sleep in its target."
 	color = "#664300" // rgb: 102, 67, 0
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 
@@ -301,9 +302,9 @@
 	toxpwr = 0.5
 
 datum/reagent/toxin/mutetoxin //the new zombie powder.
-	name = "Nulvocisine"
+	name = "Mute Toxin"
 	id = "mutetoxin"
-	description = "A toxin that temporarily paralyzes the vocal cords."
+	description = "A nonlethal poison that inhibits speech in its victim."
 	color = "#F0F8FF" // rgb: 240, 248, 255
 	toxpwr = 0
 
@@ -314,7 +315,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/staminatoxin
 	name = "Tirizene"
 	id = "tirizene"
-	description = "A toxin that affects the stamina of a person when injected into the bloodstream."
+	description = "A nonlethal poison that causes extreme fatigue and weakness in its victim."
 	color = "#6E2828"
 	data = 13
 	toxpwr = 0
@@ -355,7 +356,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/polonium
 	name = "Polonium"
 	id = "polonium"
-	description = "Cause significant Radiation damage over time."
+	description = "An extremely radioactive material in liquid form. Ingestion results in fatal irradiation."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
@@ -368,7 +369,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/histamine
 	name = "Histamine"
 	id = "histamine"
-	description = "A dose-dependent toxin, ranges from annoying to incredibly lethal."
+	description = "Histamine's effects become more dangerous depending on the dosage amount. They range from mildly annoying to incredibly lethal."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -400,7 +401,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/formaldehyde
 	name = "Formaldehyde"
 	id = "formaldehyde"
-	description = "Deals a moderate amount of Toxin damage over time. 10% chance to decay into 10-15 histamine."
+	description = "Formaldehyde, on its own, is a fairly weak toxin. It contains trace amounts of Histamine, very rarely making it decay into Histamine."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -415,7 +416,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/venom
 	name = "Venom"
 	id = "venom"
-	description = "Will deal scaling amounts of Toxin and Brute damage over time. 15% chance to decay into 5-10 histamine."
+	description = "An exotic poison extracted from highly toxic fauna. Causes scaling amounts of toxin damage and bruising depending and dosage. Often decays into Histamine."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -432,7 +433,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/neurotoxin2
 	name = "Neurotoxin"
 	id = "neurotoxin2"
-	description = "Deals toxin and brain damage up to 60 before it slows down, causing confusion and a knockout after 18 elapsed cycles."
+	description = "Neurotoxin will inhibit brain function and cause toxin damage before eventually knocking out its victim."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -449,7 +450,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/cyanide
 	name = "Cyanide"
 	id = "cyanide"
-	description = "Deals toxin damage, alongside some oxygen loss. 8% chance of stun and some extra toxin damage."
+	description = "An infamous poison known for its use in assassination. Causes small amounts of toxin damage with a small chance of oxygen damage or a stun."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
@@ -504,7 +505,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/initropidril
 	name = "Initropidril"
 	id = "initropidril"
-	description = "Causes some toxin damage, 5% chances to cause stunning, suffocation, or immediate heart failure."
+	description = "A powerful poison with insidious effects. It can cause stuns, lethal breathing failure, and cardiac arrest."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -535,7 +536,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/pancuronium
 	name = "Pancuronium"
 	id = "pancuronium"
-	description = "Knocks you out after 10 seconds, 20% chance to cause some oxygen loss."
+	description = "An undetectable toxin that swiftly incapacitates its victim. May also cause breathing failure."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
@@ -551,7 +552,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/sodium_thiopental
 	name = "Sodium Thiopental"
 	id = "sodium_thiopental"
-	description = "Puts you to sleep after 10 seconds, along with some major stamina loss."
+	description = "Sodium Thiopental induces heavy weakness in its target as well as unconsciousness."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
@@ -566,7 +567,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/sulfonal
 	name = "Sulfonal"
 	id = "sulfonal"
-	description = "Deals some toxin damage, and puts you to sleep after 22 seconds."
+	description = "A stealthy poison that deals minor toxin damage and eventually puts the target to sleep."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
@@ -580,7 +581,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/amanitin
 	name = "Amanitin"
 	id = "amanitin"
-	description = "On the last second that it's in you, it hits you with a stack of toxin damage based on how long it's been in you. The more you use, the longer it takes before anything happens, but the harder it hits when it does."
+	description = "A very powerful delayed toxin. Upon full metabolization, a massive amount of toxin damage will be dealt depending on how long it has been in the victim's bloodstream."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	toxpwr = 0
@@ -593,7 +594,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/lipolicide
 	name = "Lipolicide"
 	id = "lipolicide"
-	description = "Deals some toxin damage unless they keep eating food. Will reduce nutrition values."
+	description = "A powerful toxin that will destroy fat cells, massively reducing body weight in a short time. More deadly to those without nutriment in their body."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -611,7 +612,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/coniine
 	name = "Coniine"
 	id = "coniine"
-	description = "Does moderate toxin damage and oxygen loss."
+	description = "Coniine metabolizes extremely slowly, but deals high amounts of toxin damage and stops breathing."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.06 * REAGENTS_METABOLISM
@@ -624,7 +625,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 /datum/reagent/toxin/curare
 	name = "Curare"
 	id = "curare"
-	description = "Does some oxygen and toxin damage, weakens you after 11 seconds."
+	description = "Causes slight toxin damage followed by constant weakening and oxygen damage."
 	reagent_state = LIQUID
 	color = "#CF3600"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
@@ -634,6 +635,40 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 	if(current_cycle >= 11)
 		M.Weaken(3)
 	M.adjustOxyLoss(1*REM)
+	..()
+
+/datum/reagent/toxin/heparin //Based on a real-life anticoagulant. I'm not a doctor, so this won't be realistic.
+	name = "Heparin"
+	id = "heparin"
+	description = "A powerful anticoagulant. Victims will bleed uncontrollably and suffer scaling bruising."
+	reagent_state = LIQUID
+	color = "#C8C8C8" //RGB: 200, 200, 200
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	toxpwr = 0
+
+/datum/reagent/toxin/heparin/on_mob_life(mob/living/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		H.blood_max += 2
+		H.adjustBruteLoss(1) //Brute damage increases with the amount they're bleeding
+	..()
+
+/datum/reagent/toxin/teslium //Teslium. Causes periodic shocks, and makes shocks against the target much more effective.
+	name = "Teslium"
+	id = "teslium"
+	description = "An unstable, electrically-charged metallic slurry. Periodically electrocutes its victim, and makes electrocutions against them more deadly."
+	reagent_state = LIQUID
+	color = "#20324D" //RGB: 32, 50, 77
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	toxpwr = 0
+	var/shock_timer = 0
+
+/datum/reagent/toxin/teslium/on_mob_life(mob/living/M)
+	shock_timer++
+	if(shock_timer >= rand(5,30)) //Random shocks are wildly unpredictable
+		shock_timer = 0
+		M.electrocute_act(rand(5,20), "Teslium in their body", 1, 1) //Override because it's caused from INSIDE of you
+		playsound(M, "sparks", 50, 1)
 	..()
 
 

--- a/code/modules/reagents/Chemistry-Recipes/Medicine.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Medicine.dm
@@ -116,6 +116,12 @@
 	required_reagents = list("sodium" = 1, "phenol" = 1, "carbon" = 1, "oxygen" = 1, "sacid" = 1)
 	result_amount = 5
 
+/datum/chemical_reaction/oxandrolone
+	name = "Oxandrolone"
+	id = "oxandrolone"
+	result = "oxandrolone"
+	required_reagents = list("carbon" = 3, "phenol" = 1, "hydrogen" = 1, "oxygen" = 1)
+	result_amount = 6
 
 /datum/chemical_reaction/salbutamol
 	name = "Salbutamol"
@@ -207,5 +213,9 @@
 	required_reagents = list("stable_plasma" = 1, "acetone" = 1, "mutagen" = 1)
 	result_amount = 3
 
-
-
+/datum/chemical_reaction/haloperidol
+	name = "Haloperidol"
+	id = "haloperidol"
+	result = "haloperidol"
+	required_reagents = list("chlorine" = 1, "fluorine" = 1, "aluminium" = 1, "potass_iodide" = 1, "oil" = 1)
+	result_amount = 5

--- a/code/modules/reagents/Chemistry-Recipes/Toxins.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Toxins.dm
@@ -93,3 +93,20 @@
 	result = "mindbreaker"
 	required_reagents = list("silicon" = 1, "hydrogen" = 1, "charcoal" = 1)
 	result_amount = 5
+
+/datum/chemical_reaction/heparin
+	name = "Heparin"
+	id = "Heparin"
+	result = "heparin"
+	required_reagents = list("formaldehyde" = 1, "sodium" = 1, "chlorine" = 1, "lithium" = 1)
+	result_amount = 4
+	mix_message = "<span class='danger'>The mixture thins and loses all color.</span>"
+
+/datum/chemical_reaction/teslium
+	name = "Teslium"
+	id = "teslium"
+	result = "teslium"
+	required_reagents = list("plasma" = 1, "silver" = 1, "blackpowder" = 1)
+	result_amount = 3
+	mix_message = "<span class='danger'>A jet of sparks flies from the mixture as it merges into a flickering slurry.</span>"
+	required_temp = 400

--- a/html/changelogs/xthedark-TGChemPort_1.yml
+++ b/html/changelogs/xthedark-TGChemPort_1.yml
@@ -1,0 +1,15 @@
+author: xthedark
+
+delete-after: True
+
+changes: 
+  - rscadd: "Ported chemistry balances as well as two new chems from /tg/ made by Xhuis (optimumtact). Teslium and Heparin."
+  - rscadd: "Teslium is made from Plasma, Silver, and Black Powder, heated to 400K. Causes random (damaging) shocks to the person every 5-30 seconds and increases shock damage received by 1.5."
+  - rscadd: "Heparin is made from Formaldehyde, Sodium, Chlorine, and Lithium. Makes you bleed and causes brute damage every tick."
+  - tweak: "Port: Amatoxin and Lexorin are a bit more powerful now."
+  - tweak: "Port: Morphine causes knockout only after 24 cycles now (up from 12)."
+  - tweak: "Port: Oculine actually cures blindness/nearsightedness now."
+  - tweak: "Port: Atropine and Epinephrine now are 100% effective for anyone in crit (below 0 health)."
+  - rscadd: "Ported new medical chem from /tg/ by bgobandit - Oxandrolone made from 3 parts Carbon, 1 part of Hydrogen, Oxygen and Phenol. Twice as effective as silver sulfadrazine against heavy burns, half as effective otherwise."
+  - rscadd: "Ported new medical chem from /tg/ by Ressler (markressler) - Haloperidol. Made from Chlorine, Fluorine, Aluminum, Potassium Iodide, and Oil. Quickly purges body of drugs (methaphetamine, etc)."
+  


### PR DESCRIPTION
Special request by Adam Le-Tablemaster

Ported over chemistry additions and new descriptions from tgstation/-tg-station#13062 by @optimumtact
Oxadrolone ported from tgstation/-tg-station#11380 by @bgobandit
Haloperidol ported from tgstation/-tg-station#14057 by @markressler
### New toxins and healing chems: teslium, heparin, oxandrolone, haloperidol
- Teslium. Made from Plasma, Silver, and Black Powder, heated to 400K. Increases shock damage by 1.5, randomly shocks you for 5-20 (pre-adjustment) damage every 5-30 seconds. Metabolizes at a rate of 0.2 per tick. **Extremely deadly from me testing this.**
- Heparin. Made from Formaldehyde, Sodium, Chlorine, and Lithium. Makes you bleed aggressively and does 1 brute damage each tick. Metabolizes at a rate of 0.08 per tick. Sort of mediocre deadliness, but blood loss is relatively hard to counter.
- Oxandrolone. Made from 3 parts Carbon, 1 part of Hydrogen, Oxygen and Phenol. Twice as effective as silver sulfadiazine against heavy burns (>50 fire damage), half as effective otherwise.
- Haloperidol. Made from Chlorine, Fluorine, Aluminum, Potassium Iodide, and Oil. Quickly purges body of drugs (meth/bath salts/etc). Doesn't purge Stimulants (stimpacks), since those are medical drugs.
### Medical chem balances
- Synaptizine toxloss chance reduced to 30% (from 60%).
- Rezadone instantly heals all clone damage.
- Diphenhydramine drowsiness chance reduced to 10% (from 50%), removes 3 Histamine per tick (up from 1.5).
- Pentetic Acid no longer has a chance to cause brute damage.
- **Morphine nerfed, knocks you out after 24 cycles** (up from 12). After 12 cycles, you become drowsy.
- Oculine actually cures Blindness/Nearsightedness disabilities, not just eye damage.
- Atropine and Epinephrine now are 100% effective for anyone in crit (below 0 health).
### Toxin chem balances
- Amatoxin power increased from 1 to 2.5.
- Lexorin does not cause organ damage, but instead is even better at stopping breathing.
