### PR TITLE
Chef's meat locker now confers immunity to nukes (feature request #163)

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -255,7 +255,11 @@ var/datum/subsystem/ticker/ticker
 			if(M.stat != DEAD)
 				var/turf/T = get_turf(M)
 				if(((station_missed == 0) && T && (T.z==1)) || ((station_missed > 1) && T && (T.z == station_missed)))
-					M.death(0) //no mercy
+					// The chef's meat locker is lead-lined to improve the taste of the meat
+					if (!istype(M.loc, /obj/structure/closet/secure_closet/freezer/meat))
+						M.death(0) //no mercy
+					else
+						M << "The freezer wobbles a bit, then stops. You let out a sigh of relief.";
 
 	//Now animate the cinematic
 	switch(station_missed)

--- a/html/changelogs/toneo--lead-freezer.yml
+++ b/html/changelogs/toneo--lead-freezer.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: toneo-
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Chef's meat locker now confers nuke immunity. Do with this as you will."


### PR DESCRIPTION
(see issue #163)

Minor change, 4 lines in one file.

The chef's meat locker is the only lead-lined freezer as he is a militant vegan. If you hide in the other freezers you will find only death and bacon.
This shouldn't affect antag greentext - nukeops wins regardless of deaths, as does malfai, etc, etc.
