### PR TITLE
Adds chat logging for several methods of communication

### DIFF
--- a/code/game/gamemodes/cybermen/cybermen_abilities.dm
+++ b/code/game/gamemodes/cybermen/cybermen_abilities.dm
@@ -143,6 +143,8 @@
 	var/input = stripped_input(user, "Enter a message to share with all other Cybermen.", "Cybermen Broadcast", "")
 	if(input)
 		cyberman_network.log_broadcast("[user]([user.ckey ? user.ckey : "No ckey"]) Sent a Cyberman Broadcast: [input]")
+		log_say("[key_name(user)] : [input]")
+		user.say_log_silent += "Cyberman Broadcast: [input]"
 		for(var/datum/mind/cyberman in cyberman_network.cybermen)
 			var/distorted_message = input
 			if(cyberman.cyberman.emp_hit)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -313,7 +313,7 @@
 	attack_self(usr)
 
 
-/obj/item/device/gangtool/proc/ping_gang(mob/user)
+/obj/item/device/gangtool/proc/ping_gang(mob/living/user)
 	if(!user)
 		return
 	var/message = stripped_input(user,"Discreetly send a gang-wide message.","Send Message") as null|text
@@ -339,6 +339,8 @@
 			else
 				gang_rank = "[gang_rank - 1]th Lieutenant"
 		var/ping = "<span class='danger'><B><i>[gang.name] [gang_rank]</i>: [message]</B></span>"
+		log_say("[key_name(user)] : [message]")
+		user.say_log_silent += "Gang Chat: [message]"
 		for(var/datum/mind/ganger in members)
 			if(ganger.current && (ganger.current.z <= 2) && (ganger.current.stat == CONSCIOUS))
 				ganger.current << ping

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -362,6 +362,8 @@
 		var/text = stripped_input(user, "What do you want to say your thralls and fellow shadowlings?.", "Hive Chat", "")
 		if(!text)
 			return
+		log_say("[key_name(user)] : [text]")
+		user.say_log_silent += "Shadowling Hivemind: [text]"
 		for(var/mob/M in mob_list)
 			if(is_shadow_or_thrall(M) || (M in dead_mob_list))
 				M << "<span class='shadowling'><b>\[Shadowling\]</b><i> [usr.real_name]</i>: [text]</span>"

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -657,6 +657,8 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 /datum/species/abductor/handle_speech(message)
 	//Hacks
 	var/mob/living/carbon/human/user = usr
+	log_say("[key_name(user)] : [message]")
+	user.say_log_silent += "Abductor Chat: [message]"
 	for(var/mob/living/carbon/human/H in mob_list)
 		if(H.dna.species.id != "abductor")
 			continue

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -54,5 +54,6 @@
 	var/smoke_delay = 0 //used to prevent spam with smoke reagent reaction on mob.
 
 	var/list/say_log = list() //a log of what we've said, plain text, no spans or junk, essentially just each individual "message"
+	var/list/say_log_silent = list() //a log of things that are not said out loud, such as binary chat, changeling chat, shadlowing commune, etc.
 
 	var/unique_name = 0 //if a mob's name should be appended with an id when created e.g. Mob (666)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -211,6 +211,7 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 			if(2)
 				var/msg = "<i><font color=#800080><b>[mind.changeling.changelingID]:</b> [message]</font></i>"
 				log_say("[mind.changeling.changelingID]/[src.key] : [message]")
+				say_log_silent += "Changeling Hivemind: [message]"
 				for(var/mob/M in mob_list)
 					if(M in dead_mob_list)
 						M << msg

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -43,6 +43,7 @@
 //For holopads only. Usable by AI.
 /mob/living/silicon/ai/proc/holopad_talk(message)
 	log_say("[key_name(src)] : [message]")
+	say_log_silent += "Holopad Talk: [message]"
 
 	message = trim(message)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -6,6 +6,7 @@
 
 /mob/living/proc/robot_talk(message)
 	log_say("[key_name(src)] : [message]")
+	say_log_silent += "Binary Chat: [message]"
 	var/desig = "Default Cyborg" //ezmode for taters
 	if(istype(src, /mob/living/silicon))
 		var/mob/living/silicon/S = src

--- a/code/modules/mob/living/simple_animal/friendly/drone/say.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/say.dm
@@ -42,5 +42,7 @@
 
 
 /mob/living/simple_animal/drone/proc/drone_chat(msg)
+	log_say("[key_name(src)] : [msg]")
+	say_log_silent += "Drone Chat: [msg]"
 	var/rendered = "<i><span class='game say'>DRONE CHAT: <span class='name'>[name]</span>: [msg]</span></i>"
 	alert_drones(rendered, 1)

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -22,7 +22,17 @@
 		return
 
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	usr.emote("me",1,message)
 
+/mob/living/me_verb(message as text)
+	set name = "Me"
+	set category = "IC"
+	if(say_disabled)	//This is here to try to identify lag problems
+		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
+		return
+
+	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
+	say_log_silent += "Emote: [message]"
 	usr.emote("me",1,message)
 
 /mob/proc/say_dead(var/message)

--- a/html/changelogs/Cruix - Chat Logging.yml
+++ b/html/changelogs/Cruix - Chat Logging.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - rscadd: "Admins can now view what mobs have said through emotes, binary chat, drone chat, gang chat, changeling chat, cyberman broadcast, holopad talking, abductor chat, and shadowling chat."


### PR DESCRIPTION
Refer to issue #204.

Added speech logging for emotes, changeling chat, binary chat, drone chat, holopad talking, shadowling chat, cyberman chat, and abductor chat.

These are all placed in the new mob/living var say_log_silent. All the logs are prefixed by the method of communication used, i.e., "Emote: Blatantly disregards the /me rules."
