### PR TITLE
Buffs sending plasma to centcomm and nerfs the syndicate crate cost.

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -25,7 +25,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/points_per_slip = 2				//points gained per slip returned
 	var/points_per_crate = 5			//points gained per crate returned
 	var/points_per_intel = 250			//points gained per intel returned
-	var/points_per_plasma = 5			//points gained per plasma returned
+	var/points_per_plasma = 10			//points gained per plasma returned
 	var/points_per_design = 25			//points gained per max reliability research design returned (only for initilally unreliable designs)
 	var/centcom_message = ""			//Remarks from Centcom on how well you checked the last order.
 	var/list/discoveredPlants = list()	//Typepaths for unusual plants we've already sent CentComm, associated with their potencies

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -156,7 +156,7 @@ var/list/all_supply_groups = list(supply_emergency,supply_security,supply_engine
 /datum/supply_packs/emergency/syndicate
 	name = "ERROR_NULL_ENTRY"
 	contains = list(/obj/item/weapon/storage/box/syndicate)
-	cost = 140
+	cost = 280
 	containertype = /obj/structure/closet/crate
 	containername = "crate"
 	hidden = 1

--- a/html/changelogs/AsV9-cargo-nerf.yml
+++ b/html/changelogs/AsV9-cargo-nerf.yml
@@ -1,0 +1,7 @@
+author: AsV9
+
+delete-after: True
+
+changes: 
+  - rscadd: "Sending plasma to CentComm now rewards 10 pts instead of 5."
+  - tweak: "Syndicate crates now are twice as expensive."

--- a/html/changelogs/_VALID_PREFIXES.txt
+++ b/html/changelogs/_VALID_PREFIXES.txt
@@ -1,0 +1,25 @@
+# Valid Prefixes: 
+
+#   bugfix
+
+#   wip (For works in progress)
+
+#   tweak
+
+#   soundadd
+
+#   sounddel
+
+#   rscadd (general adding of nice things)
+
+#   rscdel (general deleting of nice things)
+
+#   imageadd
+
+#   imagedel
+
+#   spellcheck (typo fixes)
+
+#   experiment
+
+#   tgs (TG-ported fixes?)


### PR DESCRIPTION
Plasma now gives you 10 pts instead of 5.
Syndicate crate which has a random syndicate bundle inside now costs 280 pts instead of 140.

Reason: Bekons.

It's absurd when someone buys 50 fucking bundle crates.
