### PR TITLE
Adding Cortical Borers to Xenoscience

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -46,6 +46,14 @@ var/list/mob/living/simple_animal/borer/borers = list()
 
 	borers += src
 
+/mob/living/simple_animal/borer/attack_ghost(mob/user)
+	if(src.ckey)
+		return
+	var/be_swarmer = alert("Become a cortical borer? (Warning, You can no longer be cloned!)",,"Yes","No")
+	if(be_swarmer == "No")
+		return
+	transfer_personality(user.client)
+
 /mob/living/simple_animal/borer/Stat()
 	..()
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -116,16 +116,16 @@
 							if(prob(50))
 								for(var/j = 1, j <= rand(1, 3), j++)
 									step(B, pick(NORTH,SOUTH,EAST,WEST))
+							for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+								O.show_message(text("<span class='notice'>Some sort of alien slug has crawled out of the slime extract!</span>"), 1)
 
 							var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
 							if(!candidates.len)
-								//Spawn a non player controlled borer, animatable with light pink
+								//Spawn a non player controlled borer, animatable with light pink slime potion
 								for(var/mob/O in viewers(get_turf(holder.my_atom),null))
 									O.show_message(text("<span class='notice'>You get a vague feeling that something is missing.</span>"), 1)  //Alert bystanders that their borer is braindead
 							else
 								B.transfer_personality(pick(candidates))
-								for(var/mob/O in viewers(get_turf(holder.my_atom),null))
-									O.show_message(text("<span class='notice'>Some sort of alien slug has crawled out of the slime extract!</span>"), 1)
 
 						if(/obj/item/unactivated_swarmer)
 							var/obj/item/unactivated_swarmer/U = new
@@ -133,8 +133,8 @@
 							if(prob(50))
 								for(var/j = 1, j <= rand(1, 3), j++)
 									step(U, pick(NORTH,SOUTH,EAST,WEST))
-								for(var/mob/O in viewers(get_turf(holder.my_atom),null))
-									O.show_message(text("<span class='notice'>Some sort of alien machine has been formed from the slime extract!</span>"), 1)
+							for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+								O.show_message(text("<span class='notice'>The slime extract shudders, then forms some sort of alien machine!</span>"), 1)
 
 /datum/chemical_reaction/proc/goonchem_vortex(turf/simulated/T, setting_type, range)
 	for(var/atom/movable/X in orange(range, T))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -70,7 +70,7 @@
 		                        /mob/living/simple_animal/cow,
 		                        /mob/living/simple_animal/chicken) // and possible friendly mobs
 		nicecritters += typesof(/mob/living/simple_animal/pet) - /mob/living/simple_animal/pet
-		nicecritters += spec_include  //Since spec_include mobs are neither friendly nor hostile, they get into both lists
+		//nicecritters += spec_include  //Uncomment to include special mobs in friendly spawns
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/area/my_area = get_area(T)

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -59,7 +59,9 @@
 			/mob/living/simple_animal/hostile/guardian/bomb,
 			/mob/living/simple_animal/hostile/guardian/shield
 			)//exclusion list for things you don't want the reaction to create.
+		var/spec_include = list(/mob/living/simple_animal/borer)  //Special spawnable mobs (not hostile)
 		var/list/meancritters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
+		meancritters += spec_include
 		var/list/nicecritters = list(/mob/living/simple_animal/crab,
 		                        /mob/living/simple_animal/mouse,
 		                        /mob/living/simple_animal/lizard,
@@ -68,6 +70,7 @@
 		                        /mob/living/simple_animal/cow,
 		                        /mob/living/simple_animal/chicken) // and possible friendly mobs
 		nicecritters += typesof(/mob/living/simple_animal/pet) - /mob/living/simple_animal/pet
+		nicecritters += spec_include  //Since spec_include mobs are neither friendly nor hostile, they get into both lists
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/area/my_area = get_area(T)
@@ -97,7 +100,7 @@
 						step(C, pick(NORTH,SOUTH,EAST,WEST))
 			else
 				var/chosen = pick(meancritters)
-				var/mob/living/simple_animal/hostile/C = new chosen
+				var/mob/living/simple_animal/C = new chosen
 				C.faction |= mob_faction
 				C.loc = get_turf(holder.my_atom)
 				if(prob(50))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -59,9 +59,8 @@
 			/mob/living/simple_animal/hostile/guardian/bomb,
 			/mob/living/simple_animal/hostile/guardian/shield
 			)//exclusion list for things you don't want the reaction to create.
-		var/spec_include = list(/mob/living/simple_animal/borer)  //Special spawnable mobs (not hostile)
+		var/list/specialcritters = list(/mob/living/simple_animal/borer,/obj/item/unactivated_swarmer)  //Speshul mobs for speshul reactions
 		var/list/meancritters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs
-		meancritters += spec_include
 		var/list/nicecritters = list(/mob/living/simple_animal/crab,
 		                        /mob/living/simple_animal/mouse,
 		                        /mob/living/simple_animal/lizard,
@@ -70,7 +69,6 @@
 		                        /mob/living/simple_animal/cow,
 		                        /mob/living/simple_animal/chicken) // and possible friendly mobs
 		nicecritters += typesof(/mob/living/simple_animal/pet) - /mob/living/simple_animal/pet
-		//nicecritters += spec_include  //Uncomment to include special mobs in friendly spawns
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)
 		var/area/my_area = get_area(T)
@@ -90,22 +88,53 @@
 		for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
 			C.flash_eyes()
 		for(var/i = 1, i <= amount_to_spawn, i++)
-			if (reaction_name == "Friendly Gold Slime")
-				var/chosen = pick(nicecritters)
-				var/mob/living/simple_animal/C = new chosen
-				C.faction |= mob_faction
-				C.loc = get_turf(holder.my_atom)
-				if(prob(50))
-					for(var/j = 1, j <= rand(1, 3), j++)
-						step(C, pick(NORTH,SOUTH,EAST,WEST))
-			else
-				var/chosen = pick(meancritters)
-				var/mob/living/simple_animal/C = new chosen
-				C.faction |= mob_faction
-				C.loc = get_turf(holder.my_atom)
-				if(prob(50))
-					for(var/j = 1, j <= rand(1, 3), j++)
-						step(C, pick(NORTH,SOUTH,EAST,WEST))
+			switch(reaction_name)
+				if ("Friendly Gold Slime")
+					var/chosen = pick(nicecritters)
+					var/mob/living/simple_animal/C = new chosen
+					C.faction |= mob_faction
+					C.loc = get_turf(holder.my_atom)
+					if(prob(50))
+						for(var/j = 1, j <= rand(1, 3), j++)
+							step(C, pick(NORTH,SOUTH,EAST,WEST))
+				if("Lesser Gold Slime" || "Gold Slime")
+					var/chosen = pick(meancritters)
+					var/mob/living/simple_animal/C = new chosen
+					C.faction |= mob_faction
+					C.loc = get_turf(holder.my_atom)
+					if(prob(50))
+						for(var/j = 1, j <= rand(1, 3), j++)
+							step(C, pick(NORTH,SOUTH,EAST,WEST))
+
+				if("Strange Gold Slime")  //Sooper Sekrit, don't tell anyone!
+					var/chosen = pick(specialcritters)
+					switch(chosen)
+						if(/mob/living/simple_animal/borer)
+							//Spawn and populate a borer
+							var/mob/living/simple_animal/borer/B = new
+							B.loc = get_turf(holder.my_atom)
+							if(prob(50))
+								for(var/j = 1, j <= rand(1, 3), j++)
+									step(B, pick(NORTH,SOUTH,EAST,WEST))
+
+							var/list/candidates = get_candidates(BE_ALIEN, ALIEN_AFK_BRACKET)
+							if(!candidates.len)
+								//Spawn a non player controlled borer, animatable with light pink
+								for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+									O.show_message(text("<span class='notice'>You get a vague feeling that something is missing.</span>"), 1)  //Alert bystanders that their borer is braindead
+							else
+								B.transfer_personality(pick(candidates))
+								for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+									O.show_message(text("<span class='notice'>Some sort of alien slug has crawled out of the slime extract!</span>"), 1)
+
+						if(/obj/item/unactivated_swarmer)
+							var/obj/item/unactivated_swarmer/U = new
+							U.loc = get_turf(holder.my_atom)
+							if(prob(50))
+								for(var/j = 1, j <= rand(1, 3), j++)
+									step(U, pick(NORTH,SOUTH,EAST,WEST))
+								for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+									O.show_message(text("<span class='notice'>Some sort of alien machine has been formed from the slime extract!</span>"), 1)
 
 /datum/chemical_reaction/proc/goonchem_vortex(turf/simulated/T, setting_type, range)
 	for(var/atom/movable/X in orange(range, T))

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -144,18 +144,21 @@
 	name = "Slime Crit Strange"
 	id = "m_tele5"
 	result = null
-	required_reagents = list("strange_reagent" = 5) //Grind those donk pockets
+	required_reagents = list("strange_reagent" = 2) //Grind those donk pockets
 	result_amount = 1
 	required_container = /obj/item/slime_extract/gold
 	required_other = 1
 
 /datum/chemical_reaction/slimecritstrange/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	for(var/mob/O in viewers(get_turf(holder.my_atom),null))
-		O.show_message(text("<span class='danger'>The slime extract begins to vibrate gently !</span>"), 1)
-	spawn(50)
-
-		chemical_mob_spawn(holder, 1, "Strange Gold Slime", "neutral")
+	if(prob(15))
+		for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+			O.show_message(text("<span class='danger'>The slime extract begins to vibrate gently !</span>"), 1)
+		spawn(50)
+			chemical_mob_spawn(holder, 1, "Strange Gold Slime", "neutral")
+	else
+		for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+			O.show_message(text("<span class='notice'>The slime extract seems to tense up for a moment, then relaxes.</span>"), 1)
 
 //Silver
 /datum/chemical_reaction/slimebork

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -140,6 +140,23 @@
 
 		chemical_mob_spawn(holder, 1, "Friendly Gold Slime", "neutral")
 
+/datum/chemical_reaction/slimecritstrange
+	name = "Slime Crit Strange"
+	id = "m_tele5"
+	result = null
+	required_reagents = list("strange_reagent" = 5) //Grind those donk pockets
+	result_amount = 1
+	required_container = /obj/item/slime_extract/gold
+	required_other = 1
+
+/datum/chemical_reaction/slimecritstrange/on_reaction(datum/reagents/holder)
+	feedback_add_details("slime_cores_used","[type]")
+	for(var/mob/O in viewers(get_turf(holder.my_atom),null))
+		O.show_message(text("<span class='danger'>The slime extract begins to vibrate gently !</span>"), 1)
+	spawn(50)
+
+		chemical_mob_spawn(holder, 1, "Strange Gold Slime", "neutral")
+
 //Silver
 /datum/chemical_reaction/slimebork
 	name = "Slime Bork"

--- a/html/changelogs/MacHac-XenoBorers.yml
+++ b/html/changelogs/MacHac-XenoBorers.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MacHac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Cortical Borers can now be created from gold slimes in Xenobiology."


### PR DESCRIPTION
### Intent of Pull Request
- Cortical Borers can now be spawned in xenoscience with golden slimes

Borers can be spawned in xenobiology by injecting golden slimes with plasma or blood.  Borers fall into a bit of a grey area with the gold slime code as it currently stands, as they are neither hostile nor benevolent (Unlike some other monsters that players control, like aliens).  For the moment, they are grouped in with the hostile mobs, but have no attack code and thus will act like passive animals.  To add them to the nice mobs list, uncomment line 73 in Chemistry-Recipes.dm.  As 'hostile' mobs, their spawn rate is 1/43 or 2.3%;  As nice mobs, they are significantly more common and may be as high as 1/15 or 6.7%.
