### PR TITLE
Portalgun Price reduction.

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -159,7 +159,7 @@
 	name = "Bluespace Wormhole Projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams."
 	id = "wormholeprojector"
-	req_tech = list("combat" = 6, "materials" = 6, "bluespace" = 4)
+	req_tech = list("combat" = 5, "materials" = 6, "bluespace" = 4)
 	build_type = PROTOLATHE
 	materials = list(MAT_SILVER = 1000, MAT_METAL = 5000, MAT_DIAMOND = 3000)
 	build_path = /obj/item/weapon/gun/energy/wormhole_projector

--- a/html/changelogs/Oisin100-PortalGuns.yml
+++ b/html/changelogs/Oisin100-PortalGuns.yml
@@ -1,0 +1,8 @@
+# Your name.  
+author: Oisin100
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: true
+
+changes: 
+  - tweak: "R&D can now produce portal guns with just level 5 combat. Meaning you dont need combat shotguns to make them anymore."


### PR DESCRIPTION
Simple. Portal guns research price reduced to level 5 Combat instead of level 6. Meaning you dont need combat shotguns anymore.
