### PR TITLE
Blood clotting

### DIFF
--- a/code/modules/mob/living/carbon/human/blood.dm
+++ b/code/modules/mob/living/carbon/human/blood.dm
@@ -125,6 +125,9 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			blood_max += 3
 		drip(blood_max)
 
+		if(prob(heal_rate) && blood_max)  //Chance of healing every tick.
+			blood_max -= 0.5
+
 //Makes a blood drop, leaking amt units of blood from the mob
 /mob/living/carbon/human/proc/drip(amt as num)
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -46,7 +46,7 @@
 
 	var/blood_max = 0 //how much are we bleeding
 	var/bleedsuppress = 0 //for stopping bloodloss, eventually this will be limb-based like bleeding
-	var/skinmended = 0
+	var/skinmended = 0 // for supppressing bleeding with burn based weapons.
 	var/heal_rate = 10 //Chance each tick for bleeding to be reduced by 0.5 per tick
 
 	var/list/organs = list() //Gets filled up in the constructor (human.dm, New() proc.

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -46,6 +46,7 @@
 
 	var/blood_max = 0 //how much are we bleeding
 	var/bleedsuppress = 0 //for stopping bloodloss, eventually this will be limb-based like bleeding
+	var/heal_rate = 10 //Chance each tick for bleeding to be reduced by 0.5 per tick
 
 	var/list/organs = list() //Gets filled up in the constructor (human.dm, New() proc.
 

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -46,6 +46,7 @@
 
 	var/blood_max = 0 //how much are we bleeding
 	var/bleedsuppress = 0 //for stopping bloodloss, eventually this will be limb-based like bleeding
+	var/skinmended = 0
 	var/heal_rate = 10 //Chance each tick for bleeding to be reduced by 0.5 per tick
 
 	var/list/organs = list() //Gets filled up in the constructor (human.dm, New() proc.


### PR DESCRIPTION
### Intent of Pull Request
- Bleeding gradually reduces on its own without a bandage

Players will eventually stop bleeding on their own from minor injuries.
This is nowhere near as effective as a bandage, and takes roughly a
minute to close the smallest possible cut, depending on the RNG.  Heals
too slowly for large wounds, but you no longer have to go to the
hospital after a small cut if you plan on living for more than 20
minutes.
