### PR TITLE
Restart votes now require +ADMIN instead of +SERVER and more.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -222,11 +222,11 @@ var/datum/subsystem/ticker/ticker
 		if(!config.allow_vote_restart)
 			var/admins_number = 0
 			for(var/client/admin in admins)
-				if(check_rights_for(admin, R_SERVER))
+				if(check_rights_for(admin, R_ADMIN))
 					admins_number++
 			if(admins_number == 0)
-				log_admin("No admins left with +SERVER. Restart vote allowed.")
-				message_admins("No admins left with +SERVER. Restart vote allowed.")
+				log_admin("No staff left with +ADMIN. Restart vote allowed.")
+				message_admins("No staff left with +ADMIN. Restart vote allowed.")
 				config.allow_vote_restart = 1
 
 	return 1

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -531,7 +531,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		var/hitzone = user.zone_sel.selecting
 		H.suppress_bloodloss(src.stop_bleeding)
 		H.apply_damage(5, BURN, hitzone)
-		if (H.blood_max == 1.5 to INFINITY) // basically, if it's to severe of bleeding damage, a simple lighter won't fix it. maybe try something stronger?
+		if (H.blood_max >= 1.5) // basically, if it's to severe of bleeding damage, a simple lighter won't fix it. maybe try something stronger?
 			user.visible_message("<span class='alert'>There is too much blood coming out of the wound for you to fix it with [src] and you screw up!</span>")
 			visible_message("<span class='alert'>[H]'s wounds are burned by [src], but are unable to be closed by it's flame!</span>")
 			return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -78,7 +78,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/admin_credits_set,
 	/client/proc/check_words,			/*displays cult-words*/
 	/client/proc/reset_all_tcs,		/*resets all telecomms scripts*/
-	/datum/admins/proc/cybermen_panel   //lots of cybermen options
+	/datum/admins/proc/cybermen_panel,  //lots of cybermen options
+	/client/proc/toggle_restart_vote	//moderator tool for toggling restart vote
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -767,11 +768,11 @@ var/list/admin_verbs_hideable = list(
 			if(!config.allow_vote_restart)
 				var/admins_number = 0
 				for(var/client/admin in admins)
-					if(check_rights_for(admin, R_SERVER))
+					if(check_rights_for(admin, R_ADMIN))
 						admins_number++
 				if(admins_number == 0)
-					log_admin("No admins left with +SERVER. Restart vote allowed.")
-					message_admins("No admins left with +SERVER. Restart vote allowed.")
+					log_admin("No staff left with +ADMIN. Restart vote allowed.")
+					message_admins("No staff left with +ADMIN. Restart vote allowed.")
 					config.allow_vote_restart = 1
 	feedback_add_details("admin_verb","DAS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -839,11 +840,11 @@ var/list/admin_verbs_hideable = list(
 		if(config.allow_vote_restart)
 			var/admins_number = 0
 			for(var/client/admin in admins)
-				if(check_rights_for(admin, R_SERVER))
+				if(check_rights_for(admin, R_ADMIN))
 					admins_number++
 			if(admins_number > 0)
-				log_admin("Admin joined with +SERVER. Restart vote disallowed.")
-				message_admins("Admin joined with +SERVER. Restart vote disallowed.")
+				log_admin("Staff joined with +ADMIN. Restart vote disallowed.")
+				message_admins("Staff joined with +ADMIN. Restart vote disallowed.")
 				config.allow_vote_restart = 0
 		feedback_add_details("admin_verb","RAS")
 		return
@@ -887,3 +888,17 @@ var/list/admin_verbs_hideable = list(
 
 							testing("Spawned test mob with name \"[mob.name]\" at [tile.x],[tile.y],[tile.z]")
 			while (!area && --j > 0)
+
+/client/proc/toggle_restart_vote()
+	set name = "Toggle Restart Vote"
+	set category = "Server"
+	set desc = "Toggle Restart Vote for Moderators"
+
+	if(config.allow_vote_restart == 1)
+		config.allow_vote_restart = 0
+		message_admins("[src] toggled the restart vote off.")
+		log_admin("[src] toggled the restart vote off.")
+	else
+		config.allow_vote_restart = 1
+		message_admins("[src] toggled the restart vote on.")
+		log_admin("[src] toggled the restart vote on.")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -232,9 +232,9 @@ var/next_external_rsc = 0
 
 	if(holder)
 		message_admins("Admin login: [key_name(src)]")
-		if(config.allow_vote_restart && check_rights_for(src, R_SERVER))
-			log_admin("Admin with +SERVER logged in. Restart vote disallowed.")
-			message_admins("Admin with +SERVER logged in. Restart vote disallowed.")
+		if(config.allow_vote_restart && check_rights_for(src, R_ADMIN))
+			log_admin("Staff joined with +ADMIN. Restart vote disallowed.")
+			message_admins("Staff joined with +ADMIN. Restart vote disallowed.")
 			config.allow_vote_restart = 0
 		add_admin_verbs()
 		add_donor_verbs()

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -7,11 +7,11 @@
 		if(!config.allow_vote_restart)
 			var/admins_number = 0
 			for(var/client/admin in admins)
-				if(check_rights_for(admin, R_SERVER))
+				if(check_rights_for(admin, R_ADMIN))
 					admins_number++
 			if(admins_number == 0)
-				log_admin("No admins left with +SERVER. Restart vote allowed.")
-				message_admins("No admins left with +SERVER. Restart vote allowed.")
+				log_admin("No staff left with +ADMIN. Restart vote allowed.")
+				message_admins("No staff left with +ADMIN. Restart vote allowed.")
 				config.allow_vote_restart = 1
 				/*var/cheesy_message = pick( list(  \
 					"I have no admins online!",\

--- a/html/changelogs/AsV9-RestartVotes.yml
+++ b/html/changelogs/AsV9-RestartVotes.yml
@@ -1,0 +1,8 @@
+author: AsV9
+
+delete-after: True
+
+changes: 
+  - bugfix: "Restart votes are now dependant on +ADMIN instead of +SERVER."
+  - rscadd: "New admin tool added that allows for anyone with +ADMIN to toggle restart votes."
+  - bugfix: "Fixed some wonky code."


### PR DESCRIPTION
This is due to the fact that when only moderators are on the server restart votes could be called.

In addition, I have added a button for mods to click on which toggles restart votes without the need for +SERVER, only +ADMIN. This lets moderators toggle the modes when they are alone on the server. This new button is located in the server panel.

Finally, the change located in cigs_lighters.dm is due to compilation warning. It was also sorta wonky coded. Please let me know if it was coded like this for a reason.
