### PR TITLE
Fixes honk placeholder floor tiles in mining dorms

### DIFF
--- a/_maps/map_files/generic/z5.dmm
+++ b/_maps/map_files/generic/z5.dmm
@@ -392,14 +392,14 @@
 "hB" = (/turf/simulated/wall,/area/mine/explored)
 "hC" = (/obj/structure/table,/turf/simulated/floor/carpet,/area/mine/living_quarters)
 "hD" = (/turf/simulated/floor/carpet,/area/mine/living_quarters)
-"hE" = (/obj/machinery/door/airlock{id_tag = "miningdorm1"; name = "Room 1"},/turf/simulated/floor/plasteel{dir = 2; icon_state = "carpet"},/area/mine/living_quarters)
+"hE" = (/obj/machinery/door/airlock{id_tag = "miningdorm1"; name = "Room 1"},/turf/simulated/floor/plasteel,/area/mine/living_quarters)
 "hF" = (/obj/structure/disposalpipe/trunk,/obj/structure/disposaloutlet{dir = 1},/turf/simulated/floor/plating/airless{icon_state = "asteroidplating"},/area/mine/explored)
 "hG" = (/obj/structure/cable{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple,/obj/machinery/light/small{dir = 4},/turf/simulated/floor/plasteel,/area/mine/living_quarters)
 "hH" = (/obj/structure/disposalpipe/segment,/turf/simulated/mineral/random,/area/mine/unexplored)
 "hI" = (/obj/machinery/light/small{dir = 4},/obj/machinery/door_control{id = "miningdorm2"; name = "Door Bolt Control"; normaldoorcontrol = 1; pixel_x = 25; pixel_y = 0; req_access_txt = "0"; specialfunctions = 4},/turf/simulated/floor/carpet,/area/mine/living_quarters)
 "hJ" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/simulated/floor/plating,/area/mine/living_quarters)
 "hK" = (/turf/simulated/floor/plating/airless{icon_state = "asteroidplating"},/area/mine/west_outpost)
-"hL" = (/obj/machinery/door/airlock{id_tag = "miningdorm2"; name = "Room 2"},/turf/simulated/floor/plasteel{dir = 2; icon_state = "carpet"},/area/mine/living_quarters)
+"hL" = (/obj/machinery/door/airlock{id_tag = "miningdorm2"; name = "Room 2"},/turf/simulated/floor/plasteel,/area/mine/living_quarters)
 "hM" = (/turf/space,/area/mine/explored)
 "hN" = (/obj/machinery/mech_bay_recharge_port,/obj/structure/window/reinforced{dir = 8},/turf/simulated/floor/plasteel/airless{icon_state = "asteroidfloor"},/area/mine/west_outpost)
 "hO" = (/turf/simulated/floor/mech_bay_recharge_floor/airless,/area/mine/west_outpost)
@@ -436,7 +436,7 @@
 "it" = (/turf/simulated/floor/plasteel{icon_state = "bar"},/area/mine/living_quarters)
 "iu" = (/obj/structure/stool/bed/chair,/turf/simulated/floor/plasteel{icon_state = "bar"},/area/mine/living_quarters)
 "iv" = (/obj/item/device/radio/intercom{dir = 4; name = "Station Intercom (General)"; pixel_x = 31},/turf/simulated/floor/plasteel{icon_state = "bar"},/area/mine/living_quarters)
-"iw" = (/obj/machinery/door/airlock{id_tag = "miningdorm3"; name = "Room 3"},/turf/simulated/floor/plasteel{dir = 2; icon_state = "carpet"},/area/mine/living_quarters)
+"iw" = (/obj/machinery/door/airlock{id_tag = "miningdorm3"; name = "Room 3"},/turf/simulated/floor/plasteel,/area/mine/living_quarters)
 "ix" = (/obj/structure/ore_box,/turf/simulated/floor/plasteel,/area/mine/living_quarters)
 "iy" = (/obj/machinery/recharge_station,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/plasteel,/area/mine/living_quarters)
 "iz" = (/obj/structure/closet/secure_closet/miner,/turf/simulated/floor/plasteel,/area/mine/living_quarters)
@@ -981,3 +981,4 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+

--- a/html/changelogs/Pseudomaniac - mining-tile-fix.yml
+++ b/html/changelogs/Pseudomaniac - mining-tile-fix.yml
@@ -1,0 +1,6 @@
+author: Pseudomaniac
+
+delete-after: True
+
+changes: 
+  - tweak: "Fixed the broken tiles in mining"


### PR DESCRIPTION
This should replace the honk tiles in mining dorms with normal ones. Hopefully nothing SHOULD break, but do double check this. I think some coder was trying to create a carpet there by coding it in rather than mapping it but that's only my guess.
