### PR TITLE
Nerfs Morgue Prisons

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -276,7 +276,7 @@
 	return 1
 
 /obj/structure/closet/relaymove(mob/user)
-	if(user.stat || !isturf(loc))
+	if(user.stat || !(isturf(loc) || istype(loc, /obj/structure/bodycontainer/)) )
 		return
 	if(!open())
 		user << "<span class='notice'>It won't budge!</span>"

--- a/html/changelogs/Cruix - morgues.yml
+++ b/html/changelogs/Cruix - morgues.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "You can now move out of lockers and bodybags that are closed inside of a morgue."


### PR DESCRIPTION
### Intent of your Pull Request

Makes it so you can move out of lockers and bodybags while they are closed inside of a morgue. This prevents morgues from being used as an inescapable prison.
