### PR TITLE
Xenobiology Borer Nerf

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -151,14 +151,15 @@
 
 /datum/chemical_reaction/slimecritstrange/on_reaction(datum/reagents/holder)
 	feedback_add_details("slime_cores_used","[type]")
-	if(prob(15))
+	if(prob(5))
 		for(var/mob/O in viewers(get_turf(holder.my_atom),null))
 			O.show_message(text("<span class='danger'>The slime extract begins to vibrate gently !</span>"), 1)
 		spawn(50)
 			chemical_mob_spawn(holder, 1, "Strange Gold Slime", "neutral")
 	else
 		for(var/mob/O in viewers(get_turf(holder.my_atom),null))
-			O.show_message(text("<span class='notice'>The slime extract seems to tense up for a moment, then relaxes.</span>"), 1)
+			O.show_message(text("<span class='notice'>The slime extract seems to tense up for a moment, then goes dark.</span>"), 1)
+			Uses = 0
 
 //Silver
 /datum/chemical_reaction/slimebork

--- a/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Slime_extracts.dm
@@ -159,7 +159,6 @@
 	else
 		for(var/mob/O in viewers(get_turf(holder.my_atom),null))
 			O.show_message(text("<span class='notice'>The slime extract seems to tense up for a moment, then goes dark.</span>"), 1)
-			Uses = 0
 
 //Silver
 /datum/chemical_reaction/slimebork

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -23,6 +23,9 @@
 		if(Uses == 0)
 			user << "<span class='warning'>You can't enhance a used extract!</span>"
 			return ..()
+		if(istype(src,/obj/item/slime_extract/gold))
+			user<"<span class='warning'>The extract seems to recoil from the potion!</span>"
+			return ..()
 		user <<"<span class='notice'>You apply the enhancer. It now has triple the amount of uses.</span>"
 		Uses = 3
 		enhanced = 1
@@ -230,6 +233,9 @@
 		return..()
 	if(M.cores == 3)
 		user <<"<span class='warning'>The slime already has the maximum amount of extract!</span>"
+		return..()
+	if(M.colour == "gold")
+		user << "<span class='warning'>The slime recoils away from the bottle!  It won't eat it!</span>"
 		return..()
 
 	user <<"<span class='notice'>You feed the slime the steroid. It now has triple the amount of extract.</span>"


### PR DESCRIPTION
### Intent of Pull Request

= Adding Strange Reagent to a gold slime extract will now fail 95% of the time instead of 85%
- Gold slime extracts are now locked to one use, and cannot be enhanced.

In an attempt to cut back on the borer/swarmer spam, this PR reduces the likelihood of getting a borer or swarmer to 1/20 slime cores.  This means that it is no longer reasonably possible to get them every round, despite the best efforts of certain members of the community.

Gold slime extracts will now reject slime steroid.  This ensures that someone with both kinds of steroid can't use the same gold extract nine times, massively reducing the difficulty of getting something to spawn.  This should also cut back on mob spam from the regular reactions.
