### PR TITLE
Fixes un-hatched shadowlings being unable to Ascend

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -461,7 +461,7 @@
 					if(CM in M.mind.spell_list)
 						M.mind.spell_list -= CM
 						qdel(CM)
-					M.mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadowling_hatch)
+					//M.mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadowling_hatch)
 					M.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_ascend(null))
 					if(M == usr)
 						M << "<span class='shadowling'><i>You project this power to the rest of the shadowlings.</i></span>"


### PR DESCRIPTION
fixes #531 

Not quite sure if removing the hatch spell from all the living slings was intended or not. Im gonna assume whoever made slings did not think that a shadowling would stay unhatched long enough to gather 15 thralls...
