### PR TITLE
Fixes issues with lethal foam darts

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -242,23 +242,40 @@
 	if (modified)
 		icon_state = "foamdart_empty"
 		desc = "Its nerf or nothing! ... Although, this one doesn't look too safe."
+		if(BB)
+			BB.icon_state = "foamdart_empty"
+	else
+		icon_state = "foamdart"
+		desc = "Its nerf or nothing! Ages 8 and up."
+		if(BB)
+			BB.icon_state = "foamdart_empty"
 
 /obj/item/ammo_casing/caseless/foam_dart/attackby(obj/item/A, mob/user, params)
 	..()
+	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
 	if (istype(A, /obj/item/weapon/screwdriver) && !modified)
 		modified = 1
-		BB.damage_type = BRUTE
-		icon_state = "foamdart_empty"
-		desc = "Its nerf or nothing! ... Although, this one doesn't look too safe."
+		FD.damage_type = BRUTE
+		update_icon()
 		user << "<span class='notice'>You pop the safety cap off of [src].</span>"
-	else if ((istype(A, /obj/item/weapon/pen)) && modified && !BB.contents.len)
+	else if ((istype(A, /obj/item/weapon/pen)) && modified && !FD.pen)
 		if(!user.unEquip(A))
 			return
-		A.loc = BB
-		BB.damage = 5
-		BB.nodamage = 0
+		A.loc = FD
+		FD.pen = A
+		FD.damage = 5
+		FD.nodamage = 0
 		user << "<span class='notice'>You insert [A] into [src].</span>"
 	return
+
+/obj/item/ammo_casing/caseless/foam_dart/attack_self(mob/living/user)
+	var/obj/item/projectile/bullet/reusable/foam_dart/FD = BB
+	if(FD.pen)
+		FD.damage = initial(FD.damage)
+		FD.nodamage = initial(FD.nodamage)
+		user.put_in_hands(FD.pen)
+		user << "<span class='notice'>You remove [FD.pen] from [src].</span>"
+		FD.pen = null
 
 /obj/item/ammo_casing/caseless/foam_dart/riot
 	name = "riot foam dart"

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -41,6 +41,7 @@
 	BB.current = curloc
 	BB.yo = targloc.y - curloc.y
 	BB.xo = targloc.x - curloc.x
+	BB.ammo_casing = src
 
 	if(params)
 		var/list/mouse_control = params2list(params)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -9,6 +9,7 @@
 	hitsound = 'sound/weapons/pierce.ogg'
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it
+	var/obj/item/ammo_casing/ammo_casing = null	//The ammo_casing that fired this bullet
 	var/suppressed = 0	//Attack message
 	var/yo = null
 	var/xo = null

--- a/code/modules/projectiles/projectile/reusable.dm
+++ b/code/modules/projectiles/projectile/reusable.dm
@@ -1,25 +1,18 @@
 /obj/item/projectile/bullet/reusable
 	name = "reusable bullet"
 	desc = "How do you even reuse a bullet?"
-	var/obj/item/ammo_casing/caseless/ammo_type = /obj/item/ammo_casing/caseless/
+	var/ammo_type = /obj/item/ammo_casing/caseless/
 
 /obj/item/projectile/bullet/reusable/on_hit(atom/target, blocked = 0)
 	. = ..()
-	if (src.contents.len)
-		var/obj/content
-		for(content in src.contents)
-			content.loc = src.loc
-	else
-		new ammo_type(src.loc)
+	handle_drop()
 
 /obj/item/projectile/bullet/reusable/on_range()
-	if (src.contents.len)
-		var/obj/content
-		for(content in src.contents)
-			content.loc = src.loc
-	else
-		new ammo_type(src.loc)
+	handle_drop()
 	..()
+
+/obj/item/projectile/bullet/reusable/proc/handle_drop()
+	new ammo_type(src.loc)
 
 /obj/item/projectile/bullet/reusable/magspear
 	name = "magnetic spear"
@@ -38,6 +31,21 @@
 	icon_state = "foamdart"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart
 	range = 10
+	var/obj/item/weapon/pen/pen = null
+
+/obj/item/projectile/bullet/reusable/foam_dart/handle_drop()
+	var/obj/item/ammo_casing/caseless/foam_dart/newdart = new ammo_type(src.loc)
+	var/obj/item/ammo_casing/caseless/foam_dart/old_dart = ammo_casing
+	newdart.modified = old_dart.modified
+	if(pen)
+		var/obj/item/projectile/bullet/reusable/foam_dart/newdart_FD = newdart.BB
+		newdart_FD.pen = pen
+		pen.loc = newdart_FD
+		pen = null
+	newdart.BB.damage = damage
+	newdart.BB.nodamage = nodamage
+	newdart.BB.damage_type = damage_type
+	newdart.update_icon()
 
 /obj/item/projectile/bullet/reusable/foam_dart/riot
 	name = "riot foam dart"

--- a/html/changelogs/Cruix - lethal darts.yml
+++ b/html/changelogs/Cruix - lethal darts.yml
@@ -1,0 +1,7 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "Foam darts with the safety cap removed and foam darts with a pen inside them will now behave properly when fired."
+  - rscadd: "You can now remove pens from foam darts by using them in your hand."


### PR DESCRIPTION
Fixes #243 
This was much more work than I expected it to be.

*Lethal foam darts are no longer changed back to non-lethal darts when fired.

*Foam darts with a pen inside them are no longer destroyed when fired.
*You can now remove a pen from a foam dart by using it in your hand.
*Foam dart projectiles now have the lethal dart sprite when fired.
*Reusable projectiles are no longer deleted and drop all their contents if they had any contents by default. This functionality could be restored by overriding the new handle_drop() proc.
*Fired projectiles now store a reference to the ammo_casing that fired them.
