### PR TITLE
Dominator Tweaks

### DIFF
--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -37,6 +37,9 @@
 	..()
 	if(gang && isnum(gang.dom_timer))
 		if(gang.dom_timer > 0)
+			if(!loc || loc.z != 1)
+				healthcheck(health)
+				return
 			playsound(loc, 'sound/items/timer.ogg', 10, 0)
 			if(!warned && (gang.dom_timer < 180))
 				warned = 1

--- a/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
@@ -106,6 +106,12 @@
 		return 1
 	..()
 
+/mob/living/simple_animal/hostile/swarmer/UnarmedAttack(atom/A, proximity)
+	if(istype(A, /obj/machinery/dominator/))
+		src << "<span class='warning'>This device is attempting to corrupt our entire network; attempting to interact with it is too risky. Aborting.</span>"
+		return
+	return ..()
+
 ////CTRL CLICK FOR SWARMERS AND SWARMER_ACT()'S////
 /mob/living/simple_animal/hostile/swarmer/CtrlClickOn(atom/A)
 	face_atom(A)

--- a/html/changelogs/Cruix - dominator.yml
+++ b/html/changelogs/Cruix - dominator.yml
@@ -1,0 +1,7 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - tweak: "Dominators will now be destroyed if they leave the station z-level."
+  - rscdel: "Swarmers can no longer attack dominators."


### PR DESCRIPTION
Fixes #375 and #529

*Dominators will now be destroyed if they are moved off the station z-level.
*Swarmers can no longer attack dominators.
