### PR TITLE
Fixes pink slime extracts used on headcrabs not working right.

### DIFF
--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -351,7 +351,7 @@ var/list/sting_paths
 		user << "<span class='danger'>You lack the power to readapt your evolutions!</span>"
 		return 0
 
-/mob/proc/make_changeling()
+/mob/proc/make_changeling(var/createhuman = 0)
 	if(!mind)
 		return
 	if(!ishuman(src) && !ismonkey(src))
@@ -378,6 +378,8 @@ var/list/sting_paths
 	mind.changeling.purchasedpowers += revive_abilities
 
 	var/mob/living/carbon/C = src		//only carbons have dna now, so we have to typecaste
+	if(createhuman)
+		C = new /mob/living/carbon/human()
 	var/datum/changelingprofile/prof = mind.changeling.add_profile(C) //not really a point in typecasting here but somebody will probably get mad at me if i dont
 	mind.changeling.first_prof = prof
 	return 1

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -78,8 +78,10 @@
 
 	if(origin)
 		origin.transfer_to(M)
-		if(origin.changeling)
-			origin.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
+		ready_dna(M)
+		if(!origin.changeling)
+			M.make_changeling(1)
+		origin.changeling.purchasedpowers += new /obj/effect/proc_holder/changeling/humanform(null)
 		M.key = origin.key
 	owner.gib()
 


### PR DESCRIPTION
Ability for Xenobio to create Changelings. Yey.
These changelings do not have objectives and arent given antag status. They are normal crew and should act and be treated like normal crew.

Theres 1 runtime error what occurs but im pretty sure its not related to this change but ill add "Needs Testing" anyway.

Implements: #448
