### PR TITLE
Flashlight Flashing Fixes

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -62,7 +62,7 @@
 
 		var/mob/living/carbon/human/H = M	//mob has protective eyewear
 		if(istype(M, /mob/living/carbon/human) && ((H.head && H.head.flags_cover & HEADCOVERSEYES) || (H.wear_mask && H.wear_mask.flags_cover & MASKCOVERSEYES) || (H.glasses && H.glasses.flags_cover & GLASSESCOVERSEYES)))
-			user << "<span class='notice'>You're going to need to remove that [(H.head && H.head.flags_cover & HEADCOVERSEYES) ? "helmet" : (H.wear_mask && H.wear_mask.flags_cover & MASKCOVERSEYES) ? "mask": "glasses"] first.</span>"
+			user << "<span class='notice'>You're going to need to remove [(H.head && H.head.flags_cover & HEADCOVERSEYES) ? "that helmet" : (H.wear_mask && H.wear_mask.flags_cover & MASKCOVERSEYES) ? "that mask": "those glasses"] first.</span>"
 			return
 
 		if(M == user)	//they're using it on themselves
@@ -77,15 +77,16 @@
 		user.visible_message("<span class='warning'>[user] directs [src] to [M]'s eyes.</span>", \
 							 "<span class='danger'>You direct [src] to [M]'s eyes.</span>")
 		M << "<span class='danger'>[user] directs [src] to your eyes.</span>"
-
 		if(istype(M, /mob/living/carbon/human) || istype(M, /mob/living/carbon/monkey))	//robots and aliens are unaffected
+			M.flash_eyes(visual = 1)//this checks for blindness itself
 			if(M.stat == DEAD || M.disabilities & BLIND)	//mob is dead or fully blind
 				user << "<span class='warning'>[M] pupils don't react to the light!</span>"
 			else if(M.dna.check_mutation(XRAY))	//mob has X-RAY vision
 				user << "<span class='danger'>[M] pupils give an eerie glow!</span>"
+			else if(M.weakeyes)
+				user << "<span class='danger'>[M]'s eyes snap shut in response to the light!</span>"
 			else	//they're okay!
-				if(M.flash_eyes(visual = 1))
-					user << "<span class='notice'>[M]'s pupils narrow.</span>"
+				user << "<span class='notice'>[M]'s pupils narrow.</span>"
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -78,10 +78,10 @@
 							 "<span class='danger'>You direct [src] to [M]'s eyes.</span>")
 		M << "<span class='danger'>[user] directs [src] to your eyes.</span>"
 		if(istype(M, /mob/living/carbon/human) || istype(M, /mob/living/carbon/monkey))	//robots and aliens are unaffected
-			M.flash_eyes(visual = 1)//this checks for blindness itself
+			M.flash_eyes(visual = 1)//this checks for blindness itself.
 			if(M.stat == DEAD || M.disabilities & BLIND)	//mob is dead or fully blind
 				user << "<span class='warning'>[M] pupils don't react to the light!</span>"
-			else if(M.dna.check_mutation(XRAY))	//mob has X-RAY vision
+			else if(M.dna && M.dna.check_mutation(XRAY))	//mob has X-RAY vision
 				user << "<span class='danger'>[M] pupils give an eerie glow!</span>"
 			else if(M.weakeyes)
 				user << "<span class='danger'>[M]'s eyes snap shut in response to the light!</span>"

--- a/html/changelogs/Cruix-penlight_fix.yml
+++ b/html/changelogs/Cruix-penlight_fix.yml
@@ -1,0 +1,8 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "Shining a flashlight or penlight in someones eyes now always displays a message to the flasher."
+  - bugfix: "Xray no longer prevents someone from being flashed by a flashlight."
+  - rscadd: "Shining a flashlight in someone's eyes shows a new message if the subject is vulnerable to flashes."


### PR DESCRIPTION
Fixes #391 
### Intent of your Pull Request

*Xray no longer protects from being flashed by flashlights.
*Flashing someone's eyes with a flashlight (or penlight) now always displays a message to the user.
*Added a new message to flashing someone's eyes with a flashlight if they have weak eyes.
*Fixed a grammar issue where trying to flash someone with a flashlight said "You will have to remove that sunglasses" if they were wearing glasses.
*Fixed a nullpointer runtime if you tried to flash someone with a flashlight who did not have dna.
