### PR TITLE
Fixed catalade recipie

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes/Drugs.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Drugs.dm
@@ -2,9 +2,10 @@
 	name = "Catalade"
 	id = "catalade"
 	result = "catalade"
-	required_reagents = list("oxygen" = 1, "potassium" = 2, "ephedrine" = 2, "epinephrine" = 1, "flourine" = 2, "iodine" = 1, "methamphetamine" = 1, "lipolicide" = 1)
+	required_reagents = list("oxygen" = 1, "potassium" = 2, "ephedrine" = 2, "epinephrine" = 1, "fluorine" = 2, "lithium" = 1, "methamphetamine" = 1, "lipolicide" = 1)
 	result_amount = 4
 	required_temp = 500
+	mix_message = "The mixture begins to smell of burning rubber."
 
 /datum/chemical_reaction/space_drugs
 	name = "Space Drugs"


### PR DESCRIPTION
### Intent of Pull Request
- Catalade can now be made in chemistry.

This PR fixes a spelling error (flourine) that was preventing catalade from being made, while changing the recipe so that it no longer conflicted with potassium iodide.
