### PR TITLE
Tactical animal nerfs

### DIFF
--- a/code/game/objects/items/weapons/storage/tactical_harness.dm
+++ b/code/game/objects/items/weapons/storage/tactical_harness.dm
@@ -10,7 +10,7 @@
 	cant_hold = list(/obj/item/weapon/storage/tactical_harness) //muh recursive backpacks.
 	req_access = list(access_syndicate)
 	var/obj/item/weapon/stock_parts/cell/cell
-	var/shot_cost = 100
+	var/shot_cost = 150
 	var/charge_rate = 10
 
 	var/list/wearable_by = list()//types of animals that can wear it. Their subtypes can also wear it. Should be a /mob/living/simple_animal/hostile.
@@ -422,7 +422,7 @@
 	animal_new_desc = "A highly trained space dolphin used by the syndicate to provide light fire support and space superiority for elite commando teams."
 	new_speed = -0.3 //faster than an unencumbered human, but not too much faster.
 	rapid_fire = 1
-	shot_cost = 50
+	shot_cost = 75
 	ranged_attacks = list(/obj/item/projectile/beam = "laser")
 
 ///////////Tactical Carp///////////////////

--- a/code/game/objects/items/weapons/storage/tactical_harness.dm
+++ b/code/game/objects/items/weapons/storage/tactical_harness.dm
@@ -9,16 +9,20 @@
 	storage_slots = 21
 	cant_hold = list(/obj/item/weapon/storage/tactical_harness) //muh recursive backpacks.
 	req_access = list(access_syndicate)
+	var/obj/item/weapon/stock_parts/cell/cell
+	var/shot_cost = 100
+	var/charge_rate = 10
+
 	var/list/wearable_by = list()//types of animals that can wear it. Their subtypes can also wear it. Should be a /mob/living/simple_animal/hostile.
 	var/list/wearable_by_exact = list()//types of aninals that can wear it, but their subtypes can't (i.e. carps, but not megacarps or magicarps). Should be a /mob/living/simple_animal/hostile.
 	var/icon_state_alive
 	var/icon_state_dead
 	var/animal_new_name
 	var/animal_new_desc
-	var/attack_cooldown_cap = 2
+	var/attack_cooldown_cap = 1
 	var/rapid_fire = 0
 	var/new_speed = 0
-	var/new_health = 150
+	var/new_health = 100
 	var/new_melee_damage = 15
 
 	var/emag_active = 0
@@ -33,6 +37,8 @@
 	var/obj/screen/tac_harness/toggle_nightvision/toggle_nightvision_button
 
 /obj/item/weapon/storage/tactical_harness/New()
+	SSobj.processing += src
+	cell = new /obj/item/weapon/stock_parts/cell()
 	toggle_weapon_button = new /obj/screen/tac_harness/toggle_weapon()
 	toggle_safety_button = new /obj/screen/tac_harness/toggle_safety()
 	toggle_emag_button = new /obj/screen/tac_harness/toggle_emag()
@@ -43,6 +49,22 @@
 	for(var/i=0,i<5;i++)
 		new /obj/item/weapon/reagent_containers/food/snacks/syndicake(src)
 	..()
+
+/obj/item/weapon/storage/tactical_harness/Destroy()
+	SSobj.processing -= src
+	return ..()
+
+/obj/item/weapon/storage/tactical_harness/proc/can_shoot()
+	if(cell && cell.charge >= shot_cost)
+		return 1
+	return 0
+
+/obj/item/weapon/storage/tactical_harness/proc/handle_shoot()
+	cell.use(shot_cost)
+
+/obj/item/weapon/storage/tactical_harness/process()
+	if(cell)
+		cell.give(charge_rate)
 
 /obj/item/weapon/storage/tactical_harness/allowed(mob/M)
 	if(istype(M, /mob/living/carbon/human))
@@ -400,6 +422,7 @@
 	animal_new_desc = "A highly trained space dolphin used by the syndicate to provide light fire support and space superiority for elite commando teams."
 	new_speed = -0.3 //faster than an unencumbered human, but not too much faster.
 	rapid_fire = 1
+	shot_cost = 50
 	ranged_attacks = list(/obj/item/projectile/beam = "laser")
 
 ///////////Tactical Carp///////////////////
@@ -413,4 +436,4 @@
 	animal_new_name = "tactical space carp"
 	animal_new_desc = "A highly trained space carp used by the syndicate to provide heavy fire support and space superiority for elite commando teams."
 	ranged_attacks = list(/obj/item/projectile/beam/heavylaser = "heavy laser")
-	new_health = 300
+	new_health = 150

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -325,7 +325,9 @@
 	..(gibbed)
 
 /mob/living/simple_animal/hostile/proc/OpenFire(the_target)
-
+	if(harness && !harness.weapon_safety && harness.selected_weapon)
+		if(!harness.can_shoot())
+			return
 	var/target = the_target
 	visible_message("<span class='danger'><b>[src]</b> [ranged_message] at [target]!</span>")
 
@@ -350,7 +352,19 @@
 	ranged_cooldown = ranged_cooldown_cap
 	return
 
+/mob/living/simple_animal/hostile/Stat()
+	..()
+	if(harness && harness.cell && statpanel("Status"))
+		stat(null, "Harness Charge: [harness.cell.charge]/[harness.cell.maxcharge]([round((harness.cell.charge / harness.cell.maxcharge) * 100)]%)")
+		return 1
+
+
 /mob/living/simple_animal/hostile/proc/Shoot(target, start, user, bullet = 0)
+	if(harness && !harness.weapon_safety && harness.selected_weapon)
+		if(!harness.can_shoot())
+			return
+		else
+			harness.handle_shoot()
 	if(target == start)
 		return
 

--- a/html/changelogs/Cruix-tactitcal_animal_nerfs.yml
+++ b/html/changelogs/Cruix-tactitcal_animal_nerfs.yml
@@ -1,0 +1,7 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - tweak: "Tactical dolphin health nerfed fron 150 to 100, tactical carp health nerfed from 300 to 150."
+  - rscadd: "Tactical animal harnesses now have a slowly recharging power cell that powers their lasers. A dolphin can fire four salvos before needing to wait and recharge, and a carp can fire six shots. Their fire rate has been increased to once per second to compensate."


### PR DESCRIPTION
Refer to issue #0.
### Intent of your Pull Request

*Tactical dolphin heath reduced from 150 to 100.
*Tactical carp health reduced from 300 to 150.
*Tactical animal fire rate reverted from 1 salvo per two seconds to 1 salvo per second.
*Tactical animals now have a recharging battery in their harness that is drained by shooting. The maximum charge is 1000, a shot costs 150 for a carp and a 3-round-burst costs 225 for a dolphin, and the battery charges at a rate of 10 per second. These values are subject to change. Charge can be seen by the animal in its Status panel.
