### PR TITLE
Orbit fixes

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -252,3 +252,10 @@
 #define NO_RESULT				-4
 #define QUERY_OK				-5
 #define INSUFFICIENT_CREDITS	-6
+
+//Ghost orbit types:
+#define GHOST_ORBIT_CIRCLE		"circle"
+#define GHOST_ORBIT_TRIANGLE	"triangle"
+#define GHOST_ORBIT_HEXAGON		"hexagon"
+#define GHOST_ORBIT_SQUARE		"square"
+#define GHOST_ORBIT_PENTAGON	"pentagon"

--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -3,15 +3,24 @@
 	Turn(.) //BYOND handles cases such as -270, 360, 540 etc. DOES NOT HANDLE 180 TURNS WELL, THEY TWEEN AND LOOK LIKE SHIT
 
 
-/atom/proc/SpinAnimation(speed = 10, loops = -1)
-	var/matrix/m120 = matrix(transform)
-	m120.Turn(120)
-	var/matrix/m240 = matrix(transform)
-	m240.Turn(240)
-	var/matrix/m360 = matrix(transform)
-	speed /= 3      //Gives us 3 equal time segments for our three turns.
-	                //Why not one turn? Because byond will see that the start and finish are the same place and do nothing
-	                //Why not two turns? Because byond will do a flip instead of a turn
-	animate(src, transform = m120, time = speed, loops)
-	animate(transform = m240, time = speed)
-	animate(transform = m360, time = speed)
+/atom/proc/SpinAnimation(speed = 10, loops = -1, clockwise = 1, segments = 3)
+	if(!segments)
+		return
+	var/segment = 360/segments
+	if(!clockwise)
+		segment = -segment
+	var/list/matrices = list()
+	for(var/i in 1 to segments-1)
+		var/matrix/M = matrix(transform)
+		M.Turn(segment*i)
+		matrices += M
+	var/matrix/last = matrix(transform)
+	matrices += last
+
+	speed /= segments
+
+	animate(src, transform = matrices[1], time = speed, loops)
+	for(var/i in 2 to segments) //2 because 1 is covered above
+		animate(transform = matrices[i], time = speed)
+		//doesn't have an object argument because this is "Stacking" with the animate call above
+		//3 billion% intentional

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -451,7 +451,7 @@ var/global/list/spec_roles = list(
 					if(unlock_content)
 						dat += "<b>BYOND Membership Publicity:</b> <a href='?_src_=prefs;preference=publicity'>[(toggles & MEMBER_PUBLIC) ? "Public" : "Hidden"]</a><br>"
 						dat += "<b>Ghost Form:</b> <a href='?_src_=prefs;task=input;preference=ghostform'>[ghost_form]</a><br>"
-						dat += "<B>Ghost Orbit: </B> <a href='?_src_=prefs;task=input;preference=ghostform'>[ghost_orbit]</a><br>"
+						dat += "<B>Ghost Orbit: </B> <a href='?_src_=prefs;task=input;preference=ghostorbit'>[ghost_orbit]</a><br>"
 
 
 				dat += "</td><td width='300px' height='300px' valign='top'>"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -100,7 +100,7 @@ var/global/list/spec_roles = list(
 	var/UI_style_ai = DEFAULT_AI_UI
 	var/toggles = TOGGLES_DEFAULT
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
-	var/ghost_orbit = GHOST_ORBIT_CIRCLE
+	//var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/ghost_form = "ghost"
 	var/allow_midround_antag = 1
 
@@ -451,7 +451,7 @@ var/global/list/spec_roles = list(
 					if(unlock_content)
 						dat += "<b>BYOND Membership Publicity:</b> <a href='?_src_=prefs;preference=publicity'>[(toggles & MEMBER_PUBLIC) ? "Public" : "Hidden"]</a><br>"
 						dat += "<b>Ghost Form:</b> <a href='?_src_=prefs;task=input;preference=ghostform'>[ghost_form]</a><br>"
-						dat += "<B>Ghost Orbit: </B> <a href='?_src_=prefs;task=input;preference=ghostorbit'>[ghost_orbit]</a><br>"
+						//dat += "<B>Ghost Orbit: </B> <a href='?_src_=prefs;task=input;preference=ghostorbit'>[ghost_orbit]</a><br>"
 
 
 				dat += "</td><td width='300px' height='300px' valign='top'>"
@@ -942,11 +942,12 @@ var/global/list/spec_roles = list(
 							var/new_form = input(user, "Thanks for supporting BYOND - Choose your ghostly form:","Thanks for supporting BYOND",null) as null|anything in ghost_forms
 							if(new_form)
 								ghost_form = new_form
-					if("ghostorbit")
+					/*if("ghostorbit")
 						if(unlock_content)
 							var/new_orbit = input(user, "Thanks for supporting BYOND - Choose your ghostly orbit:","Thanks for supporting BYOND", null) as null|anything in ghost_orbits
 							if(new_orbit)
 								ghost_orbit = new_orbit
+					*/
 					if("name")
 						var/new_name = reject_bad_name( input(user, "Choose your character's name:", "Character Preference")  as text|null )
 						if(new_name)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -100,6 +100,7 @@ var/global/list/spec_roles = list(
 	var/UI_style_ai = DEFAULT_AI_UI
 	var/toggles = TOGGLES_DEFAULT
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
+	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/ghost_form = "ghost"
 	var/allow_midround_antag = 1
 
@@ -450,6 +451,7 @@ var/global/list/spec_roles = list(
 					if(unlock_content)
 						dat += "<b>BYOND Membership Publicity:</b> <a href='?_src_=prefs;preference=publicity'>[(toggles & MEMBER_PUBLIC) ? "Public" : "Hidden"]</a><br>"
 						dat += "<b>Ghost Form:</b> <a href='?_src_=prefs;task=input;preference=ghostform'>[ghost_form]</a><br>"
+						dat += "<B>Ghost Orbit: </B> <a href='?_src_=prefs;task=input;preference=ghostform'>[ghost_orbit]</a><br>"
 
 
 				dat += "</td><td width='300px' height='300px' valign='top'>"
@@ -940,6 +942,11 @@ var/global/list/spec_roles = list(
 							var/new_form = input(user, "Thanks for supporting BYOND - Choose your ghostly form:","Thanks for supporting BYOND",null) as null|anything in ghost_forms
 							if(new_form)
 								ghost_form = new_form
+					if("ghostorbit")
+						if(unlock_content)
+							var/new_orbit = input(user, "Thanks for supporting BYOND - Choose your ghostly orbit:","Thanks for supporting BYOND", null) as null|anything in ghost_orbits
+							if(new_orbit)
+								ghost_orbit = new_orbit
 					if("name")
 						var/new_name = reject_bad_name( input(user, "Choose your character's name:", "Character Preference")  as text|null )
 						if(new_name)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -117,7 +117,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["chat_toggles"]		>> chat_toggles
 	S["toggles"]			>> toggles
 	S["ghost_form"]			>> ghost_form
-	S["ghost_orbit"]		>> ghost_orbit
+	//S["ghost_orbit"]		>> ghost_orbit
 	S["agree"]				>> agree
 
 	//try to fix any outdated data if necessary
@@ -134,7 +134,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 	ghost_form		= sanitize_inlist(ghost_form, ghost_forms, initial(ghost_form))
-	ghost_orbit 	= sanitize_inlist(ghost_orbit, ghost_orbits, initial(ghost_orbit))
+	//ghost_orbit 	= sanitize_inlist(ghost_orbit, ghost_orbits, initial(ghost_orbit))
 	agree			= sanitize_integer(agree, -1, 65535, 0)
 
 	if(!be_special)
@@ -161,7 +161,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["toggles"]			<< toggles
 	S["chat_toggles"]		<< chat_toggles
 	S["ghost_form"]			<< ghost_form
-	S["ghost_orbit"]		<< ghost_orbit
+	//S["ghost_orbit"]		<< ghost_orbit
 	S["agree"]				<< agree
 
 	return 1

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -117,6 +117,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["chat_toggles"]		>> chat_toggles
 	S["toggles"]			>> toggles
 	S["ghost_form"]			>> ghost_form
+	S["ghost_orbit"]		>> ghost_orbit
 	S["agree"]				>> agree
 
 	//try to fix any outdated data if necessary
@@ -133,6 +134,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 	ghost_form		= sanitize_inlist(ghost_form, ghost_forms, initial(ghost_form))
+	ghost_orbit 	= sanitize_inlist(ghost_orbit, ghost_orbits, initial(ghost_orbit))
 	agree			= sanitize_integer(agree, -1, 65535, 0)
 
 	if(!be_special)
@@ -159,6 +161,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["toggles"]			<< toggles
 	S["chat_toggles"]		<< chat_toggles
 	S["ghost_form"]			<< ghost_form
+	S["ghost_orbit"]		<< ghost_orbit
 	S["agree"]				<< agree
 
 	return 1

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -361,7 +361,7 @@
 	prefs.save_preferences()
 	src << "Others can[(prefs.toggles & MEMBER_PUBLIC) ? "" : "not"] see whether you are a byond member."
 
-var/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost","ghost_red","ghost_black", \
+var/global/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost","ghost_red","ghost_black", \
 							"ghost_blue","ghost_yellow","ghost_green","ghost_pink", \
 							"ghost_cyan","ghost_dblue","ghost_dred","ghost_dgreen", \
 							"ghost_dcyan","ghost_grey","ghost_dyellow","ghost_dpink", "ghost_purpleswirl","ghost_funkypurp","ghost_pinksherbert","ghost_blazeit",\
@@ -392,6 +392,22 @@ var/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost","ghost_
 			ghost_image.icon_state = new_form
 			ghost_image.overlays = mob.overlays
 			ghost_image.alpha = mob.alpha
+var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOST_ORBIT_SQUARE,GHOST_ORBIT_HEXAGON,GHOST_ORBIT_PENTAGON)
+
+/client/verb/pick_ghost_orbit()
+	set name = "Choose Ghost Orbit"
+	set category = "Preferences"
+	set desc = "Choose your preferred ghostly orbit."
+	if(!is_content_unlocked())
+		return
+	var/new_orbit = input(src, "Thanks for supporting BYOND - Choose your ghostly orbit:","Thanks for supporting BYOND",null) as null|anything in ghost_orbits
+	if(new_orbit)
+		prefs.ghost_orbit = new_orbit
+		prefs.save_preferences()
+		if(istype(mob, /mob/dead/observer))
+			var/mob/dead/observer/O = mob
+			O.ghost_orbit = new_orbit
+
 
 /client/verb/toggle_intent_style()
 	set name = "Toggle Intent Selection Style"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -392,8 +392,11 @@ var/global/list/ghost_forms = list("ghost","ghostking","ghostian2","skeleghost",
 			ghost_image.icon_state = new_form
 			ghost_image.overlays = mob.overlays
 			ghost_image.alpha = mob.alpha
-var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOST_ORBIT_SQUARE,GHOST_ORBIT_HEXAGON,GHOST_ORBIT_PENTAGON)
 
+
+//var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOST_ORBIT_SQUARE,GHOST_ORBIT_HEXAGON,GHOST_ORBIT_PENTAGON)
+
+/*
 /client/verb/pick_ghost_orbit()
 	set name = "Choose Ghost Orbit"
 	set category = "Preferences"
@@ -407,6 +410,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		if(istype(mob, /mob/dead/observer))
 			var/mob/dead/observer/O = mob
 			O.ghost_orbit = new_orbit
+*/
 
 
 /client/verb/toggle_intent_style()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -15,7 +15,7 @@
 			alpha = 255
 		if (ghostimage)
 			ghostimage.icon_state = src.icon_state
-			ghost_orbit = client.prefs.ghost_orbit
+			//ghost_orbit = client.prefs.ghost_orbit
 			ghostimage.overlays = overlays
 			ghostimage.alpha = alpha
 	if(client.holder)

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -15,6 +15,7 @@
 			alpha = 255
 		if (ghostimage)
 			ghostimage.icon_state = src.icon_state
+			ghost_orbit = client.prefs.ghost_orbit
 			ghostimage.overlays = overlays
 			ghostimage.alpha = alpha
 	if(client.holder)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -23,6 +23,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/seedarkness = 1
 	var/ninjahud = 0
+	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 
 /mob/dead/observer/New(mob/body)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
@@ -224,25 +225,34 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/target = mobs[input]
 	ManualFollow(target)
 
-// This is the ghost's follow verb with an argument
+ // This is the ghost's follow verb with an argument
 /mob/dead/observer/proc/ManualFollow(atom/movable/target)
-	if(target && target != src)
-		if(following && following == target)
-			return
-		following = target
-		src << "<span class='notice'>Now following [target].</span>"
-		spawn(0)
-			var/turf/pos = get_turf(src)
-			while(loc == pos && target && following == target && client)
-				var/turf/T = get_turf(target)
-				if(!T)
-					break
-				// To stop the ghost flickering.
-				if(loc != T)
-					loc = T
-				pos = loc
-				sleep(15)
-			if (target == following) following = null
+	if (!istype(target))
+		return
+
+	var/icon/I = icon(target.icon,target.icon_state,target.dir)
+
+	var/orbitsize = (I.Width()+I.Height())*0.5
+	orbitsize -= (orbitsize/world.icon_size)*(world.icon_size*0.25)
+
+	if(orbiting != target)
+		src << "<span class='notice'>Now orbiting [target].</span>"
+
+	var/rot_seg
+
+	switch(ghost_orbit)
+		if(GHOST_ORBIT_TRIANGLE)
+			rot_seg = 3
+		if(GHOST_ORBIT_SQUARE)
+			rot_seg = 4
+		if(GHOST_ORBIT_PENTAGON)
+			rot_seg = 5
+		if(GHOST_ORBIT_HEXAGON)
+			rot_seg = 6
+		else //Circular
+			rot_seg = 36 //360/10 bby, smooth enough aproximation of a circle
+
+	orbit(target,orbitsize, FALSE, 20, rot_seg)
 
 /mob/dead/observer/proc/toggleninjahud()
 	set category = "Ghost"

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -23,7 +23,7 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/seedarkness = 1
 	var/ninjahud = 0
-	var/ghost_orbit = GHOST_ORBIT_CIRCLE
+	//var/ghost_orbit = GHOST_ORBIT_CIRCLE
 
 /mob/dead/observer/New(mob/body)
 	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
@@ -227,7 +227,25 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
  // This is the ghost's follow verb with an argument
 /mob/dead/observer/proc/ManualFollow(atom/movable/target)
-	if (!istype(target))
+	if(target && target != src)
+		if(following && following == target)
+			return
+		following = target
+		src << "<span class='notice'>Now following [target].</span>"
+		spawn(0)
+			var/turf/pos = get_turf(src)
+			while(loc == pos && target && following == target && client)
+				var/turf/T = get_turf(target)
+				if(!T)
+					break
+				// To stop the ghost flickering.
+				if(loc != T)
+					loc = T
+				pos = loc
+				sleep(15)
+			if (target == following) following = null
+//This below is ghost orbiting. I commented it out because people were annoyed.
+/*	if (!istype(target))
 		return
 
 	var/icon/I = icon(target.icon,target.icon_state,target.dir)
@@ -253,7 +271,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			rot_seg = 36 //360/10 bby, smooth enough aproximation of a circle
 
 	orbit(target,orbitsize, FALSE, 20, rot_seg)
-
+*/
 /mob/dead/observer/proc/toggleninjahud()
 	set category = "Ghost"
 	set name = "Toggle Antag Icons"

--- a/html/changelogs/AsV9-tesla-delag.yml
+++ b/html/changelogs/AsV9-tesla-delag.yml
@@ -1,0 +1,6 @@
+author: AsV9
+
+delete-after: True
+
+changes: 
+  - bugfix: "Tries to delag tesla by making orbit() more efficient."


### PR DESCRIPTION
Ported tgstation/-tg-station#13702
- Makes orbiting much less reliant on `animate()`.
- All orbits now start at North instead of East

`SpinAnimation()` has had it's logic un-hardcoded, that is to say, it no longer forces 3 segments of rotation on Atoms, it instead contains an argument allowing potentially infinite segments (I suspect post 360 to get a bit ~weird~)
Profiling reveals that this performs at the same CPU cost.

This should help delag the tesla.
