### PR TITLE
Inquisitiveness default off.

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -1,4 +1,4 @@
-/client/var/inquisitive_ghost = 1
+/client/var/inquisitive_ghost = 0
 /mob/dead/observer/verb/toggle_inquisition() // warning: unexpected inquisition
 	set name = "Toggle Inquisitiveness"
 	set desc = "Sets whether your ghost examines everything on click by default"

--- a/html/changelogs/Groudonmaster-Inquisitiveness.yml
+++ b/html/changelogs/Groudonmaster-Inquisitiveness.yml
@@ -1,36 +1,6 @@
-################################
-# Example Changelog File
-#
-# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-#
-# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-# When it is, any changes listed below will disappear.
-#
-# Valid Prefixes: 
-#   bugfix
-#   wip (For works in progress)
-#   tweak
-#   soundadd
-#   sounddel
-#   rscadd (general adding of nice things)
-#   rscdel (general deleting of nice things)
-#   imageadd
-#   imagedel
-#   spellcheck (typo fixes)
-#   experiment
-#   tgs (TG-ported fixes?)
-#################################
-
-# Your name.  
 author: Groudonmaster
 
-# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
 
-# Any changes you've made.  See valid prefix list above.
-# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-# SCREW THIS UP AND IT WON'T WORK.
-# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak:  "Inquisitiveness defaults to off as a ghost. Can still be reenabled in ghost tab.
+  - tweak: "Inquisitiveness defaults to off as a ghost. Can still be reenabled in ghost tab."

--- a/html/changelogs/Groudonmaster-Inquisitiveness.yml
+++ b/html/changelogs/Groudonmaster-Inquisitiveness.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Groudonmaster
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak:  "Inquisitiveness defaults to off as a ghost. Can still be reenabled in ghost tab.


### PR DESCRIPTION
Ignore the branch name.

Changes Ghost inquisitiveness to default off.
Attempted to make it toggleable in preferences but couldn't figure it out.

Whatever this works too.

Mainly for players like me that use the mouse pointer to move around as a ghost and don't want to go to the ghost tab to shut it off all the time.
