### PR TITLE
Removes tactical dolphins and tactical carps from the gold slime core spawn list.

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -57,7 +57,9 @@
 			/mob/living/simple_animal/hostile/guardian/ranged,
 			/mob/living/simple_animal/hostile/guardian/bluespace,
 			/mob/living/simple_animal/hostile/guardian/bomb,
-			/mob/living/simple_animal/hostile/guardian/shield
+			/mob/living/simple_animal/hostile/guardian/shield,
+			/mob/living/simple_animal/hostile/carp/tactical,
+			/mob/living/simple_animal/hostile/retaliate/dolphin/tactical
 			)//exclusion list for things you don't want the reaction to create.
 		var/list/specialcritters = list(/mob/living/simple_animal/borer,/obj/item/unactivated_swarmer)  //Speshul mobs for speshul reactions
 		var/list/meancritters = typesof(/mob/living/simple_animal/hostile) - blocked // list of possible hostile mobs


### PR DESCRIPTION
### Intent of your Pull Request

Removes tactical dolphins and tactical carps from the gold slime core spawn list.
<sub>Removes tactical dolphins and tactical carps from the gold slime core spawn list.</sub>
<sub><sub>Removes tactical dolphins and tactical carps from the gold slime core spawn list.</sub></sub>
<sub><sub><sub>Removes tactical dolphins and tactical carps from the gold slime core spawn list.</sub></sub></sub>
