### PR TITLE
Tesla Ball Fixes

### DIFF
--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -61,6 +61,7 @@
 			<A href='?src=\ref[src];secrets=whiteout'>Fix all lights</A><BR>
 			<A href='?src=\ref[src];secrets=floorlava'>The floor is lava! (DANGEROUS: extremely lame)</A><BR>
 			<A href='?src=\ref[src];secrets=nerfwar'>Nerf War</A><BR>
+			<A href='?src=\ref[src];secrets=ghost_bias'>Set Ghost Tesla Attraction %</a><BR>
 			<BR>
 			<A href='?src=\ref[src];secrets=changebombcap'>Change bomb cap</A><BR>
 			"}
@@ -610,6 +611,13 @@
 					new /obj/item/toy/sword(get_turf(H))
 				playsound(get_turf(H),'sound/magic/Summon_guns.ogg', 50, 1)
 			message_admins("[key_name_admin(usr)] has spawned foam-force guns for the entire crew.")
+		if("ghost_bias")
+			if(!check_rights(R_FUN))
+				return
+			var/new_Bias = input("What % chance does will the Tesla be attracted to a ghost?", "Ghost Bias", tesla_ghost_bias)
+			new_Bias = clamp(text2num(new_Bias) || tesla_ghost_bias, 0, 100)
+			message_admins("[key_name_admin(usr)] has set the tesla's ghost bais to [new_Bias].")
+			tesla_ghost_bias = new_Bias
 
 	if(E)
 		E.processing = 0

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -615,7 +615,7 @@
 			if(!check_rights(R_FUN))
 				return
 			var/new_Bias = input("What % chance does will the Tesla be attracted to a ghost?", "Ghost Bias", tesla_ghost_bias)
-			new_Bias = clamp(text2num(new_Bias) || tesla_ghost_bias, 0, 100)
+			new_Bias = min(max(text2num(new_Bias) || tesla_ghost_bias, 0), 100)
 			message_admins("[key_name_admin(usr)] has set the tesla's ghost bais to [new_Bias].")
 			tesla_ghost_bias = new_Bias
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -1,6 +1,8 @@
 #define TESLA_DEFAULT_POWER 3476520
 #define TESLA_MINI_POWER 1738260
 
+var/tesla_ghost_bias = 5;
+
 var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 										/obj/machinery/power/emitter,
 										/obj/machinery/field/generator,
@@ -69,8 +71,8 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	spawn(-1)
 		for(var/i = 0, i < move_amount, i++)
 			var/move_dir = pick(alldirs)
-			for (var/mob/dead/observer/ghost in range(7))
-				if(prob(10))
+			for (var/mob/dead/observer/ghost in range(21, get_turf(src)))
+				if(prob(tesla_ghost_bias))
 					move_dir = get_dir(src, ghost) // Ghosts are mildly conductive. For shinanigains.
 
 			var/turf/T = get_step(src,move_dir)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -69,7 +69,7 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	spawn(-1)
 		for(var/i = 0, i < move_amount, i++)
 			var/move_dir = pick(alldirs)
-			for (var/mob/dead/observer/ghost in view(7))
+			for (var/mob/dead/observer/ghost in range(7))
 				if(prob(10))
 					move_dir = get_dir(src, ghost) // Ghosts are mildly conductive. For shinanigains.
 

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -37,6 +37,10 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 	..()
 
 /obj/singularity/energy_ball/process()
+	var/b = 255 // Always blue.
+	var/r = min(rand(200, 255), b) // Random amounts of red, No more than blue however. Means it fluctates purples and blues.
+	var/g = min(rand(200, 255), r) // Like above, but with red for the green. For the same reason.
+	color = rgb(r, g, b) // Pretty Colours...
 	if(!is_orbiting)
 		handle_energy()
 		var/amount_to_move = 2 + orbiting_balls.len * 2
@@ -62,15 +66,23 @@ var/list/blacklisted_tesla_types = list(/obj/machinery/atmospherics,
 
 
 /obj/singularity/energy_ball/proc/move_the_basket_ball(var/move_amount)
-	for(var/i = 0, i < move_amount, i++)
-		var/move_dir = pick(alldirs)
-		var/turf/T = get_step(src,move_dir)
-		if(can_move(T))
-			loc = get_step(src,move_dir)
+	spawn(-1)
+		for(var/i = 0, i < move_amount, i++)
+			var/move_dir = pick(alldirs)
+			for (var/mob/dead/observer/ghost in view(7))
+				if(prob(10))
+					move_dir = get_dir(src, ghost) // Ghosts are mildly conductive. For shinanigains.
+
+			var/turf/T = get_step(src,move_dir)
+			if(can_move(T))
+				loc = get_step(src,move_dir)
+				pixel_x = -32
+				pixel_y = -32
+				if (move_amount - i <= 10) // Only do the last ten moves, so that it never starts to overlap.
+					sleep(1)
 
 /obj/singularity/energy_ball/proc/handle_energy()
-	if(energy >= 300)
-		energy = 0
+	while(energy >= 300)
 		energy -= 300
 		playsound(src.loc, 'sound/magic/lightning_chargeup.ogg', 100, 1, extrarange = 30)
 		spawn(100)

--- a/html/changelogs/TehFlaminTaco - TeslaFixes.yml
+++ b/html/changelogs/TehFlaminTaco - TeslaFixes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Teh Flamin' Taco
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Tesla Ball now is various colours of purple, blue, and white. Electric Rainbow."
+  - buxfix: "Tesla Ball now correctly stays centered, instead of drifting north east occasionally."
+  - rscadd: "Ghosts are now midly conductive, and the Telsa ball is bias towards following large groups of ghosts."


### PR DESCRIPTION
Tesla ball now varies in colour (Purples, Blues, And Whites) And changes
between them.
Tesla ball now actually stays in the centre, instead of drifting back to
x, y 0 0.
Tesla ball now has a ghost bias. Nothing overpowered, but if enough
players want the tesla ball to fuck something up, they can persuade it.
