### PR TITLE
Fixes simple animals being unable to speak

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -582,3 +582,5 @@
 		languages &= ~HUMAN
 		. = ..()
 		languages = old_langs
+		return
+	return ..()

--- a/html/changelogs/Cruix-simple_animal_speaking.yml
+++ b/html/changelogs/Cruix-simple_animal_speaking.yml
@@ -1,0 +1,7 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed simple animals being unable to speak."
+  - tweak: "Accidentally  broke simple animal speaking."


### PR DESCRIPTION
Fixes #598
### Intent of your Pull Request

I broke simple animals that could speak human in the tactical dolphin update. This fixes that.
