### PR TITLE
Bugfix for Shades and Cult/Wiz Tweak

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -266,6 +266,13 @@
 		ghost = pick(consenting_candidates)
 		if(C.contents.len) //If they used the soulstone on someone else in the meantime
 			return 0
+
+		if(imprinted != "empty") // If the soul stone is already occupied by a shade
+			return 0
+
+		if(!T)
+			return 0
+
 		if(!T.client) //If the original returns in the alloted time
 			T.client = ghost
 		for(var/obj/item/W in T)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -67,6 +67,11 @@
 /mob/living/simple_animal/construct/narsie_act()
 	return
 
+/mob/living/simple_animal/construct/examine(mob/user)
+	. = ..()
+	if((iscultist(user) || iswizard(user)) && (!src.key || !src.client))
+		user << "<span class='danger'>You can tell that they've lost all concious awareness and have become as engaging as a blank wall.</span>"
+
 /////////////////Juggernaut///////////////
 
 

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -43,3 +43,8 @@
 	else
 		..()
 	return
+
+/mob/living/simple_animal/shade/examine(mob/user)
+	. = ..()
+	if((iscultist(user) || iswizard(user)) && (!src.key || !src.client))
+		user << "<span class='danger'>You can also tell that they've lost all conscious awareness and have become as engaging as a blank wall.</span>"

--- a/html/changelogs/Super3222-ShadePatch.yml
+++ b/html/changelogs/Super3222-ShadePatch.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Added a patch for the shade bug so you will no longer be kicked from your corpse."

--- a/html/changelogs/Super3222-ShadePatch.yml
+++ b/html/changelogs/Super3222-ShadePatch.yml
@@ -11,3 +11,4 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - bugfix: "Added a patch for the shade bug so you will no longer be kicked from your corpse."
+  - tweak: "Cultists/Wizards can now tell when constructs and shades are braindead or not."


### PR DESCRIPTION
### Intent of your Pull Request

*A patch for the #17, which was a bug where shades got popped out when they already took a spot.

*Cultists/Wizards can now tell whether constructs or shades are braindead or not.
