### PR TITLE
Removes Enfeebling Sting

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -242,6 +242,7 @@
 	feedback_add_details("changeling_powers","HS")
 	return 1
 
+/*
 /obj/effect/proc_holder/changeling/sting/stamina
 	name = "Enfeebling Sting"
 	desc = "Exhausts, then causes the victim to collapse for a medium duration."
@@ -259,7 +260,8 @@
 	feedback_add_details("changeling_powers", "KS")
 	return 1
 
-/*/obj/effect/proc_holder/changeling/sting/cryo
+
+/obj/effect/proc_holder/changeling/sting/cryo
 	name = "Cryogenic Sting"
 	desc = "We silently sting a human with a cocktail of chemicals that freeze them."
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing."

--- a/html/changelogs/Super3222-nofeeble.yml
+++ b/html/changelogs/Super3222-nofeeble.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Removes the unbalanced enfeebling sting for the extent of murderboner week."


### PR DESCRIPTION
### Intent of your Pull Request

Removes enfeebling sting (finally). Changelings won't find it on their evolution menu.

This was a request considering the server is undergoing a social experiment by removing the murderbone rule.
