### PR TITLE
Fixes ssair trying to proc unsimulated turfs.

### DIFF
--- a/code/LINDA/LINDA_turf_tile.dm
+++ b/code/LINDA/LINDA_turf_tile.dm
@@ -134,10 +134,10 @@
 
 
 
+/turf/proc/process_cell()
+	SSair.remove_from_active(src)
 
-
-
-/turf/simulated/proc/process_cell()
+/turf/simulated/process_cell()
 
 	if(archived_cycle < SSair.times_fired) //archive self if not already done
 		archive()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -121,11 +121,12 @@ var/datum/subsystem/air/SSair
 		if(MC_TICK_CHECK)
 			return
 /datum/subsystem/air/proc/remove_from_active(turf/simulated/T)
+	active_turfs -= T
 	if(istype(T))
 		T.excited = 0
-		active_turfs -= T
 		if(T.excited_group)
 			T.excited_group.garbage_collect()
+	
 /datum/subsystem/air/proc/add_to_active(turf/simulated/T, blockchanges = 1)
 	if(istype(T) && T.air)
 		T.excited = 1


### PR DESCRIPTION
An active/excited simulated turf would get deleted and converted to space, so this would change the turf in ssair's active_turfs list to a space turf, then it would runtime trying to call process_cell on it. (why byond!)

Before a : and some lack of caring and a type check handled this. I removed this thinking it wasn't needed when i did my lag fix. (My exact thought was "why would an unsimulated turf get in ssair's active turf list, that seems like a bug that shouldn't get hidden" i forgot that deleting a turf just converts it to a space turf and all existing references are updated by byond to point to the new space turf)

this OOP way seems better anyways.
