### PR TITLE
Deployable Barrier Buff v1

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -257,5 +257,6 @@ for reference:
 	s.start()
 
 	explosion(src.loc,-1,-1,0)
+	playsound(src.loc, 'sound/effects/Explosion1.ogg',75,1)
 	if(src)
 		qdel(src)

--- a/html/changelogs/Super3222-deployablebuff.yml
+++ b/html/changelogs/Super3222-deployablebuff.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: N3X15
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "The deployable (security) barrier will now play a loud enough noise to be heard by someone from a dsitance."


### PR DESCRIPTION
### Intent of your Pull Request

Currently deployable barriers are the easiest thing to get through, even without an emag.

Currently you could destroy a barrier with a toolbox or a fire extinguisher under 10 seconds and it goes completely unnoticed until someone walks over and sees the rods left over from the barrier and the small environment damage.

So my mission is to make it loud enough for someone from a long, but fair distance to hear it.

I could use feedback from people who play security often.
