### PR TITLE
Fixes toggleable energy guns shooting the wrong type of shot once after toggling

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -58,7 +58,7 @@
 	if(chambered && !chambered.BB) //if BB is null, i.e the shot has been fired...
 		var/obj/item/ammo_casing/energy/shot = chambered
 		power_supply.use(shot.e_cost)//... drain the power_supply cell
-		chambered = null 
+		chambered = null
 		newshot()
 	else
 		chambered = null //either way, released the prepared shot
@@ -71,6 +71,11 @@
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay
+	if(chambered)
+		var/obj/item/ammo_casing/energy/chambered_energy = chambered
+		if(istype(chambered_energy))
+			power_supply.give(chambered_energy.e_cost)//refund!
+	process_chamber()
 	if (shot.select_name)
 		user << "<span class='notice'>[src] is now set to [shot.select_name].</span>"
 	update_icon()

--- a/html/changelogs/Cruix-toggle_eguns.yml
+++ b/html/changelogs/Cruix-toggle_eguns.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed toggleable energy guns firing the wrong type of shot once after toggling."


### PR DESCRIPTION
Fixes #444
### Intent of your Pull Request

Fixes toggleable energy guns shooting the wrong type of shot once after toggling. The old shot is refunded.
