### PR TITLE
High Risk Item Logging

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -14,3 +14,4 @@ var/global/list/chemical_reagents_list				//list of all /datum/reagent datums in
 var/global/list/surgeries_list = list()				//list of all surgeries by name, associated with their path.
 var/global/list/table_recipes = list()				//list of all table craft recipes
 var/global/list/apcs_list = list()					//list of all Area Power Controller machines, seperate from machines for powernet speeeeeeed.
+var/global/list/antag_objective_items = list()		//all items that could be antag objecives.

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -599,6 +599,25 @@
 		var/obj_count = 1
 		for(var/datum/objective/objective in objectives)
 			out += "<B>[obj_count]</B>: [objective.explanation_text] <a href='?src=\ref[src];obj_edit=\ref[objective]'>Edit</a> <a href='?src=\ref[src];obj_delete=\ref[objective]'>Delete</a> <a href='?src=\ref[src];obj_completed=\ref[objective]'><font color=[objective.completed ? "green" : "red"]>Toggle Completion</font></a><br>"
+			var/list/located_targets = objective.locate_targets()
+			if(located_targets)
+				out += "<ul>"
+				for(var/i = 1, i<=min(3, located_targets.len), i++)
+					var/target = located_targets[i]
+					out += "<li>[target]: "
+					var/turf/T = get_turf(target)
+					if(T)
+						out += "[T.x], [T.y], [T.z] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)"
+						if(T.z != 1)
+							out += "<font color='red'> Warning: Target not on station z-level.</font>"
+					else
+						out += "No loc"
+					out += "</li>"
+				if(located_targets.len > 3)
+					out += "<li>...</li>"
+				if(!located_targets.len)
+					out += "<font color='red'>Warning: No valid target in world, or target is not high-risk.</font>"
+				out += "</ul>"
 			obj_count++
 	out += "<a href='?src=\ref[src];obj_add=1'>Add objective</a><br><br>"
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -64,6 +64,10 @@
 
 //Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
+	var/turf/oldTurf = get_turf(OldLoc)
+	var/turf/newTurf = get_turf(loc)
+	if(!oldTurf || !newTurf || oldTurf.z != newTurf.z)
+		on_z_level_change()
 	return 1
 
 /atom/movable/Del()
@@ -278,3 +282,7 @@
 	if (src.master)
 		return src.master.attack_hand(a, b, c)
 	return
+
+/atom/movable/proc/on_z_level_change()
+	for(var/atom/movable/A in contents)
+		A.on_z_level_change()

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -408,6 +408,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	icon_state = "nucleardisk"
 	item_state = "card-id"
 	w_class = 1.0
+	high_risk = 1
 
 /obj/item/weapon/disk/nuclear/New()
 	..()

--- a/code/game/gamemodes/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/nuclear/pinpointer.dm
@@ -11,6 +11,7 @@
 	materials = list(MAT_METAL=500)
 	var/obj/item/weapon/disk/nuclear/the_disk = null
 	var/active = 0
+	high_risk = 1
 
 /obj/item/weapon/pinpointer/Destroy()
 	active = 0

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -211,7 +211,7 @@
 	return 0
 
 
-/datum/objective/mutiny/locate_targets()
+/datum/objective/protect/locate_targets()
 	return list(target)
 
 /datum/objective/protect/update_explanation_text()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -60,6 +60,9 @@
 
 /datum/objective/proc/give_special_equipment()
 
+/datum/objective/proc/locate_targets()//returns a list of all targets, or null if targets cannot, or should not, be located (i.e., hijack has no specific targets).
+	return null
+
 /datum/objective/assassinate
 	var/target_role_type=0
 	dangerrating = 10
@@ -77,6 +80,9 @@
 			return 1
 		return 0
 	return 1
+
+/datum/objective/assassinate/locate_targets()
+	return list(target)
 
 /datum/objective/assassinate/update_explanation_text()
 	..()
@@ -106,6 +112,9 @@
 		return 0
 	return 1
 
+/datum/objective/mutiny/locate_targets()
+	return list(target)
+
 /datum/objective/mutiny/update_explanation_text()
 	..()
 	if(target && target.current)
@@ -133,6 +142,9 @@
 		if(target.current.onCentcom() || target.current.onSyndieBase())
 			return 0
 	return 1
+
+/datum/objective/maroon/locate_targets()
+	return list(target)
 
 /datum/objective/maroon/update_explanation_text()
 	if(target && target.current)
@@ -166,6 +178,9 @@
 			return 1
 	return 0
 
+/datum/objective/debrain/locate_targets()
+	return list(target)
+
 /datum/objective/debrain/update_explanation_text()
 	..()
 	if(target && target.current)
@@ -194,6 +209,10 @@
 			return 0
 		return 1
 	return 0
+
+
+/datum/objective/mutiny/locate_targets()
+	return list(target)
 
 /datum/objective/protect/update_explanation_text()
 	..()
@@ -393,6 +412,14 @@ var/global/list/possible_items = list()
 
 /datum/objective/steal/get_target()
 	return steal_target
+
+/datum/objective/steal/locate_targets()
+	var/result = list()
+	for(var/item in antag_objective_items)
+		//world << "item: [item], == null: [item == null] istype: [istype(item, steal_target)]"
+		if(item && istype(item, steal_target))
+			result += item
+	return result
 
 /datum/objective/steal/New()
 	..()
@@ -635,6 +662,9 @@ var/global/list/possible_items_special = list()
 		return 0
 	return 1
 
+/datum/objective/destroy/locate_targets()
+	return list(target)
+
 /datum/objective/destroy/update_explanation_text()
 	..()
 	if(target && target.current)
@@ -819,7 +849,8 @@ var/global/list/possible_items_special = list()
 		return 1
 	return 0
 
-
+/datum/objective/changeling_team_objective/impersonate_department/locate_targets()
+	return department_minds.Copy()
 
 
 //A subtype of impersonate_derpartment

--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -131,7 +131,7 @@
 	difficulty = 3
 	excludefromjob = list("Research Director","Scientist")
 
-/datum/objective_item/slime/check_special_completion(obj/item/slime_extract/E)
+/datum/objective_item/steal/slime/check_special_completion(obj/item/slime_extract/E)
 	if(E.Uses > 0)
 		return 1
 	return 0

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -86,6 +86,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	)
 
 	var/flags_cover = 0 //for flags such as GLASSESCOVERSEYES
+	var/high_risk = 0 //if admins should be notified when this destoryed
 
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
@@ -97,11 +98,32 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 /obj/item/device
 	icon = 'icons/obj/device.dmi'
 
+/obj/item/New()
+	if(high_risk)
+		antag_objective_items += src
+
 /obj/item/Destroy()
+	if(high_risk)
+		var/turf/T = get_turf(src)
+		message_admins("Antag objective item [src] deleted at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>). Last associated key is [src.fingerprintslast].")
+		log_game("Antag objective item [src] deleted at ([T.x],[T.y],[T.z]). Last associated key is [src.fingerprintslast].")
+		antag_objective_items -= src
 	if(ismob(loc))
 		var/mob/m = loc
 		m.unEquip(src, 1)
 	return ..()
+
+/obj/item/on_z_level_change()
+	if(high_risk)
+		var/turf/T = get_turf(src)
+		if(T)
+			message_admins("Antag objective item [src] changed z levels at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>). Last associated key is [src.fingerprintslast].")
+			log_game("Antag objective item [src] changed z levels at ([T.x],[T.y],[T.z]). Last associated key is [src.fingerprintslast].")
+		else
+			message_admins("Antag objective item [src] changed z levels at (no loc). Last associated key is [src.fingerprintslast].")
+			log_game("Antag objective item [src] changed z levels at (no loc). Last associated key is [src.fingerprintslast].")
+	..()
+
 
 /obj/item/blob_act()
 	qdel(src)

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -78,7 +78,7 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "blueprints"
 	fluffnotice = "Property of Nanotrasen. For heads of staff only. Store in high-secure storage."
-
+	high_risk = 1
 
 /obj/item/areaeditor/blueprints/attack_self(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -17,7 +17,7 @@
 	var/recharging = 0
 	var/recharge_locked = 0
 	var/obj/item/weapon/stock_parts/micro_laser/diode //used for upgrading!
-
+	high_risk = 1
 
 /obj/item/device/laser_pointer/red
 	pointer_icon_state = "red_laser"

--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -10,6 +10,7 @@
 	throw_speed = 1
 	layer = 4
 	pressure_resistance = 1
+	high_risk = 1
 
 /obj/item/documents/nanotrasen
 	desc = "\"Top Secret\" Nanotrasen documents printed on special copy-protected paper. It is filled with complex diagrams and lists of names, dates and coordinates."

--- a/code/game/objects/items/nuke_tools.dm
+++ b/code/game/objects/items/nuke_tools.dm
@@ -8,6 +8,7 @@
 	icon_state = "plutonium_core"
 	var/pulse = 0
 	var/cooldown = 0
+	high_risk = 1
 
 /obj/item/nuke_core/process()
 	if(cooldown < world.time - 40)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -230,6 +230,7 @@ update_label("John Doe", "Clowny")
 	item_state = "gold_id"
 	registered_name = "Captain"
 	assignment = "Captain"
+	high_risk = 1
 	New()
 		var/datum/job/captain/J = new/datum/job/captain
 		access = J.get_access()

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -91,11 +91,12 @@
 	desc = "A tank of compressed oxygen for use as propulsion in zero-gravity areas. This jetpack is specially reserved for the captain."
 	icon_state = "jetpack-gold"
 	item_state = "jetpack-gold"
+	high_risk = 1
 
 /obj/item/weapon/tank/jetpack/oxygen/captain/New()
 	..()
 	air_contents.oxygen = (6*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)
-	
+
 /obj/item/weapon/tank/jetpack/oxygen/harness
 	name = "jet harness (oxygen)"
 	desc = "A lightweight tactical harness, used by those who don't want to be weighed down by traditional jetpacks."

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -135,6 +135,7 @@ Frequency:
 	materials = list(MAT_METAL=10000)
 	origin_tech = "magnets=1;bluespace=3"
 	var/active_portals = 0
+	high_risk = 1
 
 /obj/item/weapon/hand_tele/attack_self(mob/user)
 	var/turf/current_location = get_turf(user)//What turf is the user on?

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -85,7 +85,9 @@
 		if(destination_y)
 			A.y = destination_y
 
-		A.z =  text2num(transition)
+		A.z = text2num(transition)
+		if(z != A.z)
+			A.on_z_level_change()
 
 		if(isliving(A))
 			var/mob/living/L = A

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -46,6 +46,7 @@
 	icon_state = "advmag0"
 	magboot_state = "advmag"
 	slowdown_active = SHOES_SLOWDOWN
+	high_risk = 1
 
 /obj/item/clothing/shoes/magboots/syndie
 	desc = "Reverse-engineered magnetic boots that have a heavy magnetic pull. Property of Gorlex Marauders."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -102,6 +102,7 @@
 	blood_overlay_type = "armor"
 	armor = list(melee = 10, bullet = 10, laser = 60, energy = 50, bomb = 0, bio = 0, rad = 0)
 	var/hit_reflect_chance = 40
+	high_risk = 1
 
 /obj/item/clothing/suit/armor/laserproof/IsReflect(def_zone)
 	if(!(def_zone in list("chest", "groin"))) //If not shot where ablative is covering you, you don't get the reflection bonus!
@@ -129,6 +130,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	action_button_name = "Toggle Armor"
 	unacidable = 1
+	high_risk = 1
 
 /obj/item/clothing/suit/armor/reactive/IsShield()
 	if(active)

--- a/code/modules/clothing/under/ties.dm
+++ b/code/modules/clothing/under/ties.dm
@@ -143,6 +143,7 @@
 /obj/item/clothing/tie/medal/gold/captain
 	name = "medal of captaincy"
 	desc = "A golden medal awarded exclusively to those promoted to the rank of captain. It signifies the codified responsibilities of a captain to Nanotrasen, and their undisputable authority over their crew."
+	high_risk = 1
 
 /obj/item/clothing/tie/medal/gold/heroism
 	name = "medal of exceptional heroism"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -32,6 +32,7 @@
 	origin_tech = null
 	var/charge_tick = 0
 	ammo_x_offset = 3
+	high_risk = 1
 
 /obj/item/weapon/gun/energy/laser/captain/New()
 	..()

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -21,6 +21,7 @@
 	force = 10
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/disabler)
 	ammo_x_offset = 4
+	high_risk = 1
 
 /obj/item/weapon/gun/energy/gun/dragnet
 	name = "DRAGnet"
@@ -56,6 +57,7 @@
 	pin = null
 	can_charge = 0
 	ammo_x_offset = 1
+	high_risk = 1
 
 /obj/item/weapon/gun/energy/gun/nuclear/New()
 	..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -66,6 +66,7 @@
 
 /obj/item/weapon/reagent_containers/hypospray/CMO
 	list_reagents = list("omnizine" = 30)
+	high_risk = 1
 
 /obj/item/weapon/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -392,6 +392,8 @@
 					if(!M.buckled)
 						M.Weaken(3)
 
+			if(T0.z != T1.z)
+				AM.on_z_level_change()
 
 		if (rotation)
 			T1.shuttleRotate(rotation)

--- a/html/changelogs/Cruix-high_risk_logging.yml
+++ b/html/changelogs/Cruix-high_risk_logging.yml
@@ -1,4 +1,4 @@
- author: Cruix
+author: Cruix
 
 delete-after: True
 

--- a/html/changelogs/Cruix-high_risk_logging.yml
+++ b/html/changelogs/Cruix-high_risk_logging.yml
@@ -1,0 +1,6 @@
+ author: Cruix
+
+delete-after: True
+
+changes: 
+  - rscadd: "Admins are now notified when a high-risk item is destroyed or changes z-levels."


### PR DESCRIPTION
### Intent of your Pull Request

*Added a new var to items, "high_risk". If this is set to 1, admins will be notified whenever it is destroyed or changes z-levels. Most traitor objective items have high_risk set to 1 by default.
*When looking at a player's objectives in the traitor panel, admins can look at and jump to the locations of their targets. Due to how object paths work, some objectives might show strange objects, like the "steal 20 moles of plasma" showing the captain's jetpack because jetpacks are air tanks. This should work for steal objectives, and objectives with particular human targets like assassinate, protect, etc.
