### PR TITLE
Fixes swarmer traps not stunning people

### DIFF
--- a/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/bot_swarm/swarmer.dm
@@ -438,7 +438,7 @@
 		var/mob/living/L = AM
 		if(!istype(L, /mob/living/simple_animal/hostile/swarmer))
 			playsound(loc,'sound/effects/snap.ogg',50, 1, -1)
-			L.electrocute_act(0, src, 1, 1)
+			L.electrocute_act(0, src, 1, override = 1)
 			if(isrobot(L))
 				L.Weaken(5)
 			qdel(src)

--- a/html/changelogs/XTheDark-swarmer_trap_fix.yml
+++ b/html/changelogs/XTheDark-swarmer_trap_fix.yml
@@ -1,0 +1,6 @@
+author: XTheDark
+
+delete-after: True
+
+changes: 
+  - bugfix: "Swarmer traps now correctly stun living creatures."


### PR DESCRIPTION
Swarmer traps now actually stun people that walk over it. No existing issue for this bug.

Tested with:
Humans - wearing/not wearing gloves - glove siemens_coefficient of 0/0.5/1/1.5
