### PR TITLE
Adds an RCD and an upgraded industrial welder to CE's locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -24,6 +24,8 @@
 	new /obj/item/device/flash/handheld(src)
 	new /obj/item/clothing/glasses/meson/engine(src)
 	new /obj/item/weapon/weldingtool/hugetank(src)
+	new /obj/item/weapon/rcd(src)
+       	
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"
 	req_access = list(access_engine_equip)

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -23,7 +23,7 @@
 	new /obj/item/device/multitool(src)
 	new /obj/item/device/flash/handheld(src)
 	new /obj/item/clothing/glasses/meson/engine(src)
-
+	new /obj/item/weapon/weldingtool/hugetank(src)
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"
 	req_access = list(access_engine_equip)


### PR DESCRIPTION
### Intent of your Pull Request

Currently, the CE has no specialized or useful gear. This PR will bring the CE in line with other heads and help him achieve the CHIEF engineer identity he lacks, assuring he has a much-needed RCD in case greedy engineers get all 3. Another benefit is that antags will actually feel good when looting his locker, because atm you can't get anything powerful/interesting from it.
