### PR TITLE
Shadowling targeting stuff

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -1086,8 +1086,8 @@
 					src.spell_list = null
 					message_admins("[key_name_admin(usr)] has de-shadowling'ed [current].")
 					log_admin("[key_name(usr)] has de-shadowling'ed [current].")
-					remove_spell(/obj/effect/proc_holder/spell/targeted/shadowling_hatch)
-					remove_spell(/obj/effect/proc_holder/spell/targeted/shadowling_ascend)
+					remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/shadowling_hatch)
+					remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/shadowling_ascend)
 				else if(src in ticker.mode.thralls)
 					ticker.mode.remove_thrall(src,0)
 					message_admins("[key_name_admin(usr)] has de-thrall'ed [current].")

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -44,6 +44,7 @@ Made by Xhuis
 
 /datum/game_mode
 	var/list/datum/mind/shadows = list()
+	var/list/datum/mind/safetyshadow = list() //Shadowlings and thralls with safety mode on (on by default)
 	var/list/datum/mind/thralls = list()
 	var/list/shadow_objectives = list()
 	var/required_thralls = 15 //How many thralls are needed (hardcoded for now)
@@ -131,9 +132,10 @@ Made by Xhuis
 
 /datum/game_mode/proc/finalize_shadowling(datum/mind/shadow_mind)
 	var/mob/living/carbon/human/S = shadow_mind.current
-	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_hatch(null))
-	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/enthrall(null))
-	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_hivemind(null))
+	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/shadowling_hatch(null))
+	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/enthrall(null))
+	shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/shadowling_hivemind(null))
+	//shadow_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/safetymode(null))
 	spawn(0)
 		update_shadow_icons_added(shadow_mind)
 		if(shadow_mind.assigned_role == "Clown")
@@ -148,10 +150,11 @@ Made by Xhuis
 		thralls += new_thrall_mind
 		new_thrall_mind.special_role = "thrall"
 		new_thrall_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Became a thrall</span>"
-		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_shadowling_hivemind(null))
-		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_glare(null))
-		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/lesser_shadow_walk(null))
-		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/thrall_vision(null))
+		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/lesser_shadowling_hivemind(null))
+		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/lesser_glare(null))
+		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/lesser_shadow_walk(null))
+		new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/thrall_vision(null))
+		//new_thrall_mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/safetymode(null))
 		new_thrall_mind.current << "<span class='shadowling'><b>You see the truth. Reality has been torn away and you realize what a fool you've been.</b></span>"
 		new_thrall_mind.current << "<span class='shadowling'><b>The shadowlings are your masters.</b> Serve them above all else and ensure they complete their goals.</span>"
 		new_thrall_mind.current << "<span class='shadowling'>You may not harm other thralls or the shadowlings. However, you do not need to obey other thralls.</span>"
@@ -166,10 +169,11 @@ Made by Xhuis
 	thralls.Remove(thrall_mind)
 	thrall_mind.current.attack_log += "\[[time_stamp()]\] <span class='danger'>Dethralled</span>"
 	thrall_mind.special_role = null
-	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/lesser_shadowling_hivemind)
-	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/lesser_glare)
-	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/lesser_shadow_walk)
-	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/thrall_vision)
+	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/lesser_shadowling_hivemind)
+	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/lesser_glare)
+	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/lesser_shadow_walk)
+	thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/thrall_vision)
+	//thrall_mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/safetymode)
 	if(kill && ishuman(thrall_mind.current)) //If dethrallization surgery fails, kill the mob as well as dethralling them
 		var/mob/living/carbon/human/H = thrall_mind.current
 		H.visible_message("<span class='warning'>[H] jerks violently and falls still.</span>", \

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -1,6 +1,6 @@
 //In here: Hatch and Ascendance
 var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "Noaey'gief", "Mii`mahza", "Amerziox", "Gyrg-mylin", "Kanet'pruunance", "Vigistaezian") //Unpronouncable 2: electric boogalo
-/obj/effect/proc_holder/spell/targeted/shadowling_hatch
+/obj/effect/proc_holder/spell/targeted/shadow/shadowling_hatch
 	name = "Hatch"
 	desc = "Casts off your disguise."
 	panel = "Shadowling Evolution"
@@ -10,7 +10,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 	include_user = 1
 	action_icon_state = "hatch"
 
-/obj/effect/proc_holder/spell/targeted/shadowling_hatch/cast(list/targets)
+/obj/effect/proc_holder/spell/targeted/shadow/shadowling_hatch/cast(list/targets)
 	if(usr.stat || !ishuman(usr) || !usr || !is_shadow(usr)) return
 	for(var/mob/living/carbon/human/H in targets)
 		var/hatch_or_no = alert(H,"Are you sure you want to hatch? You cannot undo this!",,"Yes","No")
@@ -88,18 +88,18 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 
 				sleep(10)
 				H << "<span class='shadowling'><b><i>Your powers are awoken. You may now live to your fullest extent. Remember your goal. Cooperate with your thralls and allies.</b></i></span>"
-				H.mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadowling_hatch)
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/glare(null))
+				H.mind.remove_spell(/obj/effect/proc_holder/spell/targeted/shadow/shadowling_hatch)
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/glare(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/veil(null))
 				//H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow_walk(null))	// Unneeded, No reason to have shadow_walk off.
 				//H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/major_dark_vision(null))	//Not needed, They can tell what's pure dark and not now.
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flashfreeze(null))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/collective_mind(null))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_regenarmor(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/collective_mind(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/shadowling_regenarmor(null))
 
 
 
-/obj/effect/proc_holder/spell/targeted/shadowling_ascend
+/obj/effect/proc_holder/spell/targeted/shadow/shadowling_ascend
 	name = "Ascend"
 	desc = "Enters your true form."
 	panel = "Shadowling Evolution"
@@ -109,7 +109,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 	include_user = 1
 	action_icon_state = "ascend"
 
-/obj/effect/proc_holder/spell/targeted/shadowling_ascend/cast(list/targets)
+/obj/effect/proc_holder/spell/targeted/shadow/shadowling_ascend/cast(list/targets)
 	if(usr.stat || !ishuman(usr) || !usr || !shadowling_check(usr)) return
 	for(var/mob/living/carbon/human/H in targets)
 		var/hatch_or_no = alert(H,"It is time to ascend. Are you sure about this?",,"Yes","No")
@@ -159,10 +159,10 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 					H.mind.remove_spell(S)
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/annihilate(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/hypnosis(null))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_phase_shift(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/shadowling_phase_shift(null))
 				H.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/ascendant_storm(null))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_hivemind_ascendant(null))
-				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/ascendant_transmit(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/shadowling_hivemind_ascendant(null))
+				H.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadow/ascendant_transmit(null))
 				H.mind.transfer_to(A)
 				A.name = H.real_name
 				if(A.real_name)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -58,3 +58,4 @@
 	var/heart_attack = 0
 
 	var/darksight_init = 0
+	var/safetymode = 1 //Only used for shadowlings and shadowling accessories

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/human
 	languages = HUMAN
-	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD)
+	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD,CYBERMEN_HACK_HUD)
 	//Hair colour and style
 	var/hair_color = "000"
 	var/hair_style = "Bald"
@@ -58,4 +58,6 @@
 	var/heart_attack = 0
 
 	var/darksight_init = 0
-	var/safetymode = 1 //Only used for shadowlings and shadowling accessories
+
+	var/puppetingSSD = 0
+	//var/safetymode = 1


### PR DESCRIPTION
### Intent of Pull Request

= Shadowlings will no longer try to target simple animals, allied thralls, other shadowlings, mice, pets, and other normally un-targettable enemies.  These entities will simply not show up on the targeting list.  This prevents ambushes from failing because there was a mouse within 5 meters.

Notes: There is some stuff in there about a safety mode.  I left the code in just in case anyone in the future wanted to implement it, but it's a bit outside of the scope of this PR.
Note^2: I'm pretty sure this will build.
