### PR TITLE
Shades can return to their soulstones

### DIFF
--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -73,6 +73,11 @@
 
 		if ("Summon")
 			for(var/mob/living/simple_animal/shade/A in src)
+				if(!A.key)
+					for(var/mob/dead/observer/G in player_list)
+						if(G.name == A.name && G.name == A.real_name)
+							A.key = G.key
+							G.mind.transfer_to(A)
 				A.status_flags &= ~GODMODE
 				A.canmove = 1
 				A.loc = U.loc
@@ -281,3 +286,13 @@
 		qdel(T)
 	else
 		U << "<span class='danger'>The ghost has fled beyond your grasp.</span>"
+
+/obj/item/device/soulstone/attack_ghost(mob/user)
+	if (imprinted != user.name || imprinted != user.real_name)
+		return
+
+	for(var/mob/living/simple_animal/shade/S in src)
+		user.cancel_camera()
+		S.ckey = user.ckey
+		user.mind.transfer_to(S)
+	return

--- a/html/changelogs/Super3222-GhostSoulStone.yml
+++ b/html/changelogs/Super3222-GhostSoulStone.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Ghosted shades from their soulstones can return to them (by clicking on the stone) or having another cultist summon them."


### PR DESCRIPTION
### Intent of your Pull Request
#617

Ghosted Shades can re-enter their soulstone homes by clicking on the shard.

When you summon shades out of their soulstones, it'll force the ghost into the shade as well.

FAQ:
'what if i don't wanna play'

The only solution is suicide.
