### PR TITLE
Reduces high-risk item admin notification spam

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -14,6 +14,7 @@ var/guests_allowed = 1
 var/shuttle_frozen = 0
 var/shuttle_left = 0
 var/tinted_weldhelh = 1
+var/high_risk_item_notifications = 0
 
 
 // Debug is used exactly once (in living.dm) but is commented out in a lot of places.  It is not set anywhere and only checked.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -105,7 +105,8 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 /obj/item/Destroy()
 	if(high_risk)
 		var/turf/T = get_turf(src)
-		message_admins("Antag objective item [src] deleted at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>). Last associated key is [src.fingerprintslast].")
+		if(high_risk_item_notifications)
+			message_admins("Antag objective item [src] deleted at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>). Last associated key is [src.fingerprintslast].")
 		log_game("Antag objective item [src] deleted at ([T.x],[T.y],[T.z]). Last associated key is [src.fingerprintslast].")
 		antag_objective_items -= src
 	if(ismob(loc))
@@ -117,10 +118,12 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	if(high_risk)
 		var/turf/T = get_turf(src)
 		if(T)
-			message_admins("Antag objective item [src] changed z levels at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>). Last associated key is [src.fingerprintslast].")
+			if(high_risk_item_notifications)
+				message_admins("Antag objective item [src] changed z levels at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>). Last associated key is [src.fingerprintslast].")
 			log_game("Antag objective item [src] changed z levels at ([T.x],[T.y],[T.z]). Last associated key is [src.fingerprintslast].")
 		else
-			message_admins("Antag objective item [src] changed z levels at (no loc). Last associated key is [src.fingerprintslast].")
+			if(high_risk_item_notifications)
+				message_admins("Antag objective item [src] changed z levels at (no loc). Last associated key is [src.fingerprintslast].")
 			log_game("Antag objective item [src] changed z levels at (no loc). Last associated key is [src.fingerprintslast].")
 	..()
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -985,3 +985,12 @@ datum/admins/proc/cyberman_varedit(list/href_list)
 				var/num = input("Set innate processing to what? (If this is not 0, the hack will not lose progress if no cybermen are nearby)") as num
 				if(hack)
 					hack.innate_processing = num
+
+/datum/admins/proc/toggle_high_risk_item_notifications()
+	set category = "Admin"
+	set desc="Toggle dis bitch"
+	set name="Toggle High Risk Item Notifications"
+	high_risk_item_notifications = !high_risk_item_notifications
+	var/message = "[key_name_admin(usr)] has toggled high risk item notifications [high_risk_item_notifications ? "on" : "off"]."
+	message_admins(message)
+	log_admin(message)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -79,7 +79,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/check_words,			/*displays cult-words*/
 	/client/proc/reset_all_tcs,		/*resets all telecomms scripts*/
 	/datum/admins/proc/cybermen_panel,  //lots of cybermen options
-	/client/proc/toggle_restart_vote	//moderator tool for toggling restart vote
+	/client/proc/toggle_restart_vote,	//moderator tool for toggling restart vote
+	/datum/admins/proc/toggle_high_risk_item_notifications //toggles notifying admins when objective items are destroyed or change z-levels
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -240,7 +241,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/panicbunker,
 	/client/proc/admin_change_sec_level,
 	/client/proc/toggle_nuke,
-	/client/proc/cmd_display_del_log
+	/client/proc/cmd_display_del_log,
+	/datum/admins/proc/toggle_high_risk_item_notifications
 	)
 
 /client/proc/add_admin_verbs()

--- a/html/changelogs/Cruix-high_risk_notification_spam.yml
+++ b/html/changelogs/Cruix-high_risk_notification_spam.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - rscadd: "Made admin notifications for high-risk items toggleable to reduce spam. It defaults to off."


### PR DESCRIPTION
### Intent of your Pull Request

Made admin high-risk item notifications toggleable with the "Toggle High Risk Item Notifications" verb. It defaults to off.
