### PR TITLE
Changed implant functionality

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -675,7 +675,7 @@ var/list/uplink_items = list()
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated using a bodily gesture to attempt to slip restraints."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
-	cost = 5
+	cost = 7
 
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"

--- a/code/game/objects/items/weapons/implants/implant_loyality.dm
+++ b/code/game/objects/items/weapons/implants/implant_loyality.dm
@@ -24,7 +24,11 @@
 		if(imp)
 			imp.removed(target)
 
-		if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.get_gang_bosses())) || is_shadow_or_thrall(target))
+		if(locate(/obj/item/weapon/implant/freedom) in target)
+			target << "<span class='warning'>You feel the syndicate nanobots in your bloodstream quietly deactivate the implant.  You appear to be implanted, but the implant has no effect.</span>"
+			return 1
+
+		if((target.mind in (ticker.mode.head_revolutionaries | ticker.mode.get_gang_bosses())) || is_shadow_or_thrall(target) || (target.mind.special_role))
 			target.visible_message("<span class='warning'>[target] seems to resist the implant!</span>", "<span class='warning'>You feel the corporate tendrils of Nanotrasen try to invade your mind!</span>")
 			removed(target, 1)
 			qdel(src)

--- a/html/changelogs/MacHac-ImplanterChanges.yml
+++ b/html/changelogs/MacHac-ImplanterChanges.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MacHac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "A software update has been released to all Nanotrasen loyalty implanters, allowing them to properly identify traitors and changelings.  To counter this, the Syndicate has updated its freedom implants to quietly deactivate loyalty implants on contact."


### PR DESCRIPTION
Refer to issue #733.
### Intent of Pull Request

This pull request modifies loyalty implanter functionality.  At the moment, traitors and changelings can be loyalty implanted without problems.  This makes security recruitment incredibly dangerous when another type of antagonist hasn't been confirmed.  With this PR, all special roles will now properly reject loyalty implants.  To help traitors counter this, the freedom implant (which now costs 7 crystals instead of 5) will quietly deactivate loyalty implants as they are injected, similar to trying to implant cybermen.
