### PR TITLE
Failed implantings (headrev/gangboss/etc) only show resist message

### DIFF
--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -35,11 +35,15 @@
 			if(user && M && (get_turf(M) == T) && src && imp)
 				if(M.head && (M.head.flags & THICKMATERIAL))
 					return
-				if(imp.implant(M, user))
-					user << "<span class='notice'>You implant the implant into [M].</span>"
-					M.visible_message("[user] has implanted [M].", "<span class='notice'>[user] implants you with the implant.</span>")
-					imp = null
-					update_icon()
+				switch(imp.implant(M, user))
+					if(1) //All normal
+						user << "<span class='notice'>You implant the implant into [M].</span>"
+						M.visible_message("[user] has implanted [M].", "<span class='notice'>[user] implants you with the implant.</span>")
+						imp = null
+						update_icon()
+					if(-1) //attempted to implant traitor/changeling/headrev/gangboss - don't show implanted message (less clutter in chat)
+						imp = null
+						update_icon()
 
 /obj/item/weapon/implanter/attackby(obj/item/weapon/W, mob/user, params)
 	..()

--- a/html/changelogs/xthedark-ImplantMessagingTweaks.yml
+++ b/html/changelogs/xthedark-ImplantMessagingTweaks.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Failed implanting (implanting a headrevs/gangboss) does not display the normal implanted message, letting you see resist messages more clearly."


### PR DESCRIPTION
### Intent of your Pull Request

I was going to address the loyalty implant, but MacHac beat me to it, so I might as well commit this part of the thing.

If the implanting fails (the 'implant' proc of implants returns -1), it does not say the regular "has implanted".
