### PR TITLE
Fixes #745 - Secborgs losing zipties 

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -148,6 +148,9 @@
 /obj/item/weapon/restraints/handcuffs/cable/zipties/used/attack()
 	return
 
+/obj/item/weapon/restraints/handcuffs/cable/zipties/attack_self(mob/user)
+	return
+
 
 //Legcuffs
 

--- a/html/changelogs/Super3222-ziptiebugfix.yml
+++ b/html/changelogs/Super3222-ziptiebugfix.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "You can no longer untie zipties. This'll prevent borgs from losing their own."


### PR DESCRIPTION
### Intent of your Pull Request

Fixes bug #745, where secborgs permanently lost their zipties (from pressing Z with them selected in hand). You can no longer untie them to make cable coils.
