### PR TITLE
Fixes inconsistent description changes with shield blob

### DIFF
--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -2,7 +2,7 @@
 	name = "strong blob"
 	icon = 'icons/mob/blob.dmi'
 	icon_state = "blob_idle"
-	desc = "Some stronger blob creature thingy"
+	desc = "A huge wall of writhing tendrils. It looks like it could take a lot of hits."
 	health = 150
 	maxhealth = 150
 	health_regen = 2


### PR DESCRIPTION
### Intent of your Pull Request

Shield blob was still along the lines of "blob creature thingy" and wasn't similar to every other blob description. Its new description tells the person who examined it that it'll be tough to break as well.

This is a minor change so I don't really think it needs a changelog.
