### PR TITLE
Blob Balances, Plus Bugfixes!

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -424,7 +424,7 @@
 /datum/reagent/blob/electromagnetic_web/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
 	if(prob(reac_volume*2))
-		empulse(M.loc, 1, 4)
+		empulse(M.loc, 1, 3)
 	if(M)
 		M.apply_damage(0.6*reac_volume, BURN)
 

--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -19,7 +19,7 @@
 /datum/reagent/blob/proc/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause) //when the blob takes damage, do this
 	return damage
 
-/datum/reagent/blob/proc/death_reaction(obj/effect/blob/B, cause) //when a blob dies, do this
+/datum/reagent/blob/proc/death_reaction(obj/effect/blob/B, cause = 1) //when a blob dies, do this
 	return
 
 /datum/reagent/blob/proc/expand_reaction(obj/effect/blob/B, obj/effect/blob/newB, turf/T) //when the blob expands, do this
@@ -87,7 +87,7 @@
 	return effectivedamage
 
 /datum/reagent/blob/replicating_foam/expand_reaction(obj/effect/blob/B, obj/effect/blob/newB, turf/T)
-	if(prob(40))
+	if(prob(30))
 		newB.expand() //do it again!
 
 //does brute damage, shifts away when damaged
@@ -134,7 +134,7 @@
 
 /datum/reagent/blob/energized_fibers/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	M.apply_damage(0.4*reac_volume, BURN)
+	M.apply_damage(0.5*reac_volume, BURN)
 	if(M)
 		M.adjustStaminaLoss(0.8*reac_volume)
 
@@ -181,12 +181,12 @@
 /datum/reagent/blob/flammable_goo/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
 	M.adjust_fire_stacks(round(reac_volume/10)) //apply, but don't ignite
-	M.apply_damage(0.4*reac_volume, TOX)
+	M.apply_damage(0.5*reac_volume, TOX)
 	if(M)
-		M.apply_damage(0.2*reac_volume, BURN)
+		M.apply_damage(0.3*reac_volume, BURN)
 
 /datum/reagent/blob/flammable_goo/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
-	if(cause && damage_type == BURN)
+	if(damage_type == BURN)
 		for(var/turf/T in range(1, B))
 			if(!(locate(/obj/effect/blob) in T) && prob(80))
 				PoolOrNew(/obj/effect/hotspot, T)
@@ -260,7 +260,7 @@
 		O.blob_mobs.Add(BS)
 		BS.Zombify(M)
 	if(M)
-		M.apply_damage(0.6*reac_volume, TOX)
+		M.apply_damage(0.7*reac_volume, TOX)
 
 //toxin, stamina, and some bonus spore toxin
 /datum/reagent/blob/envenomed_filaments
@@ -424,7 +424,7 @@
 /datum/reagent/blob/electromagnetic_web/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
 	if(prob(reac_volume*2))
-		M.emp_act(2)
+		empulse(M.loc, 1, 4)
 	if(M)
 		M.apply_damage(0.6*reac_volume, BURN)
 
@@ -439,7 +439,7 @@
 				return damage * 10
 	return damage * 1.25 //a laser will do 25 damage, which will kill any normal blob
 
-/datum/reagent/blob/electromagnetic_web/death_reaction(obj/effect/blob/B, cause)
+/datum/reagent/blob/electromagnetic_web/death_reaction(obj/effect/blob/B, cause = 1)
 	if(cause)
 		empulse(B.loc, 1, 3) //less than screen range, so you can stand out of range to avoid it
 
@@ -502,7 +502,7 @@
 	reac_volume = ..()
 	if(O && ishuman(M) && M.stat == UNCONSCIOUS)
 		PoolOrNew(/obj/effect/overlay/temp/revenant, get_turf(M))
-		var/points = rand(5, 10)
+		var/points = rand(8, 13)
 		O.add_points(points)
 		O << "<span class='notice'>Gained [points] resources from the death of [M].</span>"
 		M.death()
@@ -526,11 +526,9 @@
 	var/turf/simulated/T = get_turf(M)
 	if(istype(T, /turf/simulated) && prob(reac_volume))
 		T.MakeSlippery(1)
-	M.apply_damage(0.2*reac_volume, BRUTE)
+	M.apply_damage(0.4*reac_volume, BRUTE)
 	if(M)
 		M.apply_damage(0.4*reac_volume, OXY)
-	if(M)
-		M.adjustStaminaLoss(0.4*reac_volume)
 
 /datum/reagent/blob/pressurized_slime/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
 	for(var/turf/simulated/T in range(1, B))

--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -441,7 +441,8 @@
 
 /datum/reagent/blob/electromagnetic_web/death_reaction(obj/effect/blob/B, cause = 1)
 	if(cause)
-		empulse(B.loc, 1, 3) //less than screen range, so you can stand out of range to avoid it
+		if(prob(75))
+			empulse(B.loc, 1, 3) //less than screen range, so you can stand out of range to avoid it
 
 //does brute damage, bonus damage for each nearby blob, and spreads damage out
 /datum/reagent/blob/synchronous_mesh

--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -513,8 +513,8 @@
 /datum/reagent/blob/pressurized_slime
 	name = "Pressurized Slime"
 	id = "pressurized_slime"
-	description = "will do low brute, oxygen, and stamina damage, and wet tiles when damaged or killed."
-	shortdesc = "will do low brute, oxygen, and stamina damage, and wet tiles under targets."
+	description = "will do medium brute and low oxygen damage, and wets tiles when damaged or killed."
+	shortdesc = "will do low brute and oxygen, damage, and wet tiles under targets."
 	color = "#AAAABB"
 	complementary_color = "#BBBBAA"
 	blobbernaut_message = "emits slime at"

--- a/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Blob-Reagents.dm
@@ -514,7 +514,7 @@
 	name = "Pressurized Slime"
 	id = "pressurized_slime"
 	description = "will do medium brute and low oxygen damage, and wets tiles when damaged or killed."
-	shortdesc = "will do low brute and oxygen, damage, and wet tiles under targets."
+	shortdesc = "will do low brute and oxygen damage, and wet tiles under targets."
 	color = "#AAAABB"
 	complementary_color = "#BBBBAA"
 	blobbernaut_message = "emits slime at"

--- a/html/changelogs/ShadowDeath6- Blobbalance.yml
+++ b/html/changelogs/ShadowDeath6- Blobbalance.yml
@@ -1,0 +1,15 @@
+ 
+author: ShadowDeath6
+
+
+delete-after: True
+
+
+changes: 
+  - bugfix: "Fixed Flammable Goo and Electromagnetic Blob not correctly working."
+  - tweak: "Nerfed Replicating Foam Blob expansion bonus chance."
+  - tweak: "Increased Flammable Goo Blob damage and made it ignite when hit with any burn damage, not just dying from it."
+  - tweak: "Increased Zombifying Feelers Blob toxin damage."
+  - tweak: "Increased Blob Point gain from absorbing people as Adaptive Nexus Blob."
+  - tweak: "Removed stamina damage from Pressurized Slime Blob and increased regular damage."
+  - tweak: "Increased Energized Fiber Blob's damage."


### PR DESCRIPTION
Refer to issue #803 .
### Intent of your Pull Request

Minor balancing things.

Replicating Foam- 10% less chance to get the expand / damage bonus
Energized Fibers- Increased damage.
Flammable Goo- Increased damage, plus a bugfix that made it not work. Now ignites turfs around it upon taking burn damage, not just dying from it.
Zombifying Feelers- Increased Damage
Electromagnetic Web- Fixed bug causing it to not emit EMPs. Now EMPs upon death and upon attacking, attacking EMPs are slightly larger.
Adaptive Nexuses- Increased BlobPoint bonus from absorbing unconscious people.
Pressurized Slime- Removes stamina damage and increases brute damage.

Thanks to @Groxic for the help.
