### PR TITLE
Traitor/Nuke ops items cost rebalancing

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -115,14 +115,14 @@ var/list/uplink_items = list()
 	name = "Syndicate Revolver"
 	desc = "A brutally simple syndicate revolver that fires .357 Magnum cartridges and has 7 chambers."
 	item = /obj/item/weapon/gun/projectile/revolver
-	cost = 13
+	cost = 11
 	surplus = 50
 
 /datum/uplink_item/dangerous/smg
 	name = "C-20r Submachine Gun"
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun that fires .45 rounds with a 20-round magazine and is compatible with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/c20r
-	cost = 14
+	cost = 15
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 40
 
@@ -134,7 +134,7 @@ var/list/uplink_items = list()
 	name = "M-90gl Carbine"
 	desc = "A fully-loaded three-round burst carbine that uses 30-round 5.56mm magazines with a togglable underslung 40mm grenade launcher."
 	item = /obj/item/weapon/gun/projectile/automatic/m90
-	cost = 18
+	cost = 15
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 50
 
@@ -163,7 +163,7 @@ var/list/uplink_items = list()
 	name = "Flamethrower"
 	desc = "A flamethrower, fueled by a portion of highly flammable biotoxins stolen previously from Nanotrasen stations. Make a statement by roasting the filth in their own greed. Use with caution."
 	item = /obj/item/weapon/flamethrower/full/tank
-	cost = 11
+	cost = 7
 	gamemodes = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
 	surplus = 40
 
@@ -171,7 +171,7 @@ var/list/uplink_items = list()
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/weapon/melee/energy/sword/saber
-	cost = 8
+	cost = 6
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Kit"
@@ -205,7 +205,7 @@ var/list/uplink_items = list()
 	name = "Viscerator Delivery Grenade"
 	desc = "A unique grenade that deploys a swarm of viscerators upon activation, which will chase down and shred any non-operatives in the area."
 	item = /obj/item/weapon/grenade/spawnergrenade/manhacks
-	cost = 8
+	cost = 6
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 35
 
@@ -214,7 +214,7 @@ var/list/uplink_items = list()
 	desc = "A chemical sprayer that allows a wide dispersal of selected chemicals. Especially tailored by the Tiger Cooperative, the deadly blend it comes stocked with will disorient, damage, and disable your foes... \
 	Use with extreme caution, to prevent exposure to yourself and your fellow operatives."
 	item = /obj/item/weapon/reagent_containers/spray/chemsprayer/bioterror
-	cost = 20
+	cost = 15
 	gamemodes = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
 	surplus = 0
 
@@ -231,7 +231,7 @@ var/list/uplink_items = list()
 	name = "Mauler Exosuit"
 	desc = "A massive and incredibly deadly Syndicate exosuit. Features long-range targetting, thrust vectoring, and deployable smoke."
 	item = /obj/mecha/combat/marauder/mauler/loaded
-	cost = 140
+	cost = 130
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
@@ -276,7 +276,7 @@ var/list/uplink_items = list()
 	name = "Speed Loader - .357"
 	desc = "A speed loader that contains seven additional .357 Magnum rounds for the syndicate revolver. For when you really need a lot of things dead."
 	item = /obj/item/ammo_box/a357
-	cost = 4
+	cost = 2
 
 /datum/uplink_item/ammo/smg
 	name = "SMG Magazine - .45"
@@ -404,13 +404,13 @@ var/list/uplink_items = list()
 	desc = "When inserted into a personal digital assistant, this cartridge gives you five opportunities to detonate PDAs of crewmembers who have their message feature enabled. \
 	The concussive effect from the explosion will knock the recipient out for a short period, and deafen them for longer. It has a chance to detonate your PDA."
 	item = /obj/item/weapon/cartridge/syndicate
-	cost = 6
+	cost = 4
 
 /datum/uplink_item/stealthy_weapons/suppressor
 	name = "Universal Suppressor"
 	desc = "Fitted for use on any small caliber weapon with a threaded barrel, this suppressor will silence the shots of the weapon for increased stealth and superior ambushing capability."
 	item = /obj/item/weapon/suppressor
-	cost = 3
+	cost = 2
 	surplus = 10
 
 /datum/uplink_item/stealthy_weapons/pizza_bomb
@@ -424,13 +424,13 @@ var/list/uplink_items = list()
 	name = "Dehydrated Space Carp"
 	desc = "Looks like a plush toy carp, but just add water and it becomes a real-life space carp! Activate before use."
 	item = /obj/item/toy/carpplushie/dehy_carp
-	cost = 3
+	cost = 1
 
 /datum/uplink_item/stealthy_weapons/door_charge
 	name = "Explosive Airlock Charge"
 	desc = "A small, easily concealable device. It can be applied to an open airlock panel, and the next person to open that airlock will be knocked down in an explosion. The airlock's maintenance panel will also be destroyed by this."
 	item = /obj/item/device/doorCharge
-	cost = 5
+	cost = 2
 	surplus = 10
 	excludefrom = list(/datum/game_mode/nuclear)
 
@@ -489,7 +489,7 @@ var/list/uplink_items = list()
 	name = "Chameleon-Projector"
 	desc = "Projects an image across a user, disguising them as an object scanned with it, as long as they don't move the projector from their hand. Disguised users cannot run, and projectiles pass over them."
 	item = /obj/item/device/chameleon
-	cost = 7
+	cost = 4
 	excludefrom = list(/datum/game_mode/gang)
 
 /datum/uplink_item/stealthy_tools/camera_bug
@@ -522,7 +522,7 @@ var/list/uplink_items = list()
 	name = "Cryptographic Sequencer"
 	desc = "The cryptographic sequencer, or emag, is a small card that unlocks hidden functions in electronic devices, subverts intended functions and characteristically breaks security mechanisms."
 	item = /obj/item/weapon/card/emag
-	cost = 6
+	cost = 8
 	excludefrom = list(/datum/game_mode/gang)
 
 /datum/uplink_item/device_tools/toolbox
@@ -595,7 +595,7 @@ var/list/uplink_items = list()
 	name = "Hacked AI Law Upload Module"
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	item = /obj/item/weapon/aiModule/syndicate
-	cost = 14
+	cost = 8
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"
@@ -710,7 +710,7 @@ var/list/uplink_items = list()
 	desc = "An implant injected into the body, and later activated using a bodily gesture to inject a specially formulated sedative along with an anti-toxin solution to counteract some negative effects. \
 	You will appear dead to most casual observers, and will eventually wake up of your own accord. Can also be purged by medical chemistry."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_zombie
-	cost = 12
+	cost = 7
 
 /datum/uplink_item/implants/mindslave
 	name = "Mindslave Implant"
@@ -767,7 +767,7 @@ var/list/uplink_items = list()
 	name = "Syndicate Smokes"
 	desc = "Strong flavor, dense smoke, infused with Omnizine."
 	item = /obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate
-	cost = 2
+	cost = 1
 
 /datum/uplink_item/badass/bundle
 	name = "Syndicate Bundle"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -695,7 +695,7 @@ var/list/uplink_items = list()
 	name = "Storage Implant"
 	desc = "An implant injected into the body and later used to store up to two big items in a subspace pocket."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_storage
-	cost = 9
+	cost = 11
 
 /datum/uplink_item/implants/microbomb
 	name = "Microbomb Implant"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -122,7 +122,7 @@ var/list/uplink_items = list()
 	name = "C-20r Submachine Gun"
 	desc = "A fully-loaded Scarborough Arms bullpup submachine gun that fires .45 rounds with a 20-round magazine and is compatible with suppressors."
 	item = /obj/item/weapon/gun/projectile/automatic/c20r
-	cost = 15
+	cost = 13
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 40
 
@@ -489,7 +489,7 @@ var/list/uplink_items = list()
 	name = "Chameleon-Projector"
 	desc = "Projects an image across a user, disguising them as an object scanned with it, as long as they don't move the projector from their hand. Disguised users cannot run, and projectiles pass over them."
 	item = /obj/item/device/chameleon
-	cost = 4
+	cost = 5
 	excludefrom = list(/datum/game_mode/gang)
 
 /datum/uplink_item/stealthy_tools/camera_bug
@@ -522,7 +522,7 @@ var/list/uplink_items = list()
 	name = "Cryptographic Sequencer"
 	desc = "The cryptographic sequencer, or emag, is a small card that unlocks hidden functions in electronic devices, subverts intended functions and characteristically breaks security mechanisms."
 	item = /obj/item/weapon/card/emag
-	cost = 8
+	cost = 9
 	excludefrom = list(/datum/game_mode/gang)
 
 /datum/uplink_item/device_tools/toolbox
@@ -595,7 +595,7 @@ var/list/uplink_items = list()
 	name = "Hacked AI Law Upload Module"
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. Be careful with their wording, as artificial intelligences may look for loopholes to exploit."
 	item = /obj/item/weapon/aiModule/syndicate
-	cost = 8
+	cost = 9
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"
@@ -695,7 +695,7 @@ var/list/uplink_items = list()
 	name = "Storage Implant"
 	desc = "An implant injected into the body and later used to store up to two big items in a subspace pocket."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_storage
-	cost = 8
+	cost = 9
 
 /datum/uplink_item/implants/microbomb
 	name = "Microbomb Implant"

--- a/html/changelogs/UplinkItems.yml
+++ b/html/changelogs/UplinkItems.yml
@@ -1,0 +1,13 @@
+
+author: FluffySurvivor 
+
+
+
+delete-after: True
+
+
+
+changes: 
+  - tweak: "Several Syndicate items have received cost increases or decreases."
+  - tweak: "The Revolver, Explosive Airlock Charge, Dehydrated Carp Extract, Energy Sword and a few other items (some Nuke Ops exclusive items as well) have all received a price reduction"
+  - tweak:"The Cryptographic Sequencer (emag) and the Storage Implant have received a price increase."

--- a/html/changelogs/UplinkItems.yml
+++ b/html/changelogs/UplinkItems.yml
@@ -10,4 +10,4 @@ delete-after: True
 changes: 
   - tweak: "Several Syndicate items have received cost increases or decreases."
   - tweak: "The Revolver, Explosive Airlock Charge, Dehydrated Carp Extract, Energy Sword and a few other items (some Nuke Ops exclusive items as well) have all received a price reduction"
-  - tweak:"The Cryptographic Sequencer (emag) and the Storage Implant have received a price increase."
+  - tweak: "The Cryptographic Sequencer (emag) and the Storage Implant have received a price increase."


### PR DESCRIPTION
As discussed in #804 
### Intent of your Pull Request

(Finally) changing the traitor/nuke op meta by nerfing dominant items and buffing the weak/meh ones (duh). Awakening unviable tactics and creating more creativity and combinations for traitors to explore with their items

Let's get to the changes! 

**Traitors**
_Syndicate revolver_
While undoubtly a deadly item, it often required the traitor to fully commit a long time to support a revolver buy and adapt to specific strategies(setting up the ammo supplies, dealing with the ammo system, being covert because the shots have obvious sounds and so on), thus running risks and doing a lot of work that didn't always result in justifying the huge cost. Buffing to help syndiecuties to get shooting a bit earlier while not making the revolver a must-buy
Cost: 13-->11
Ammo cost: 4-->2

_Energy sword_
The signature weapon of any bloodthirsty Syndicate agent,  it often left the user feel bad due to its big lack of reliability. An esword on its own unsupported by a stun weapon often made our flashy stick of death a flashy stick of "lynch this guy". Adjusting the cost to make it feel better in other creative combos (airlock charge + esword?!). Double esword users will now feel good too as they now have access to other items for support instead of the current "disarmed and die" outcome we all see and know. 
Cost: 8-->6

_Universal Supressor_
Available at R&D as well, this will improve stealth-shooting  as an alternative to other strategies. 
Cost: 3-->2

_Cryptographic Sequencer_
Designed to be a sabotage/infiltration item, it simply always proved to be _the_ go-to item, regardless of situation, simply because it was left too cheap in contrast to other items. Pulling up the cost a bit, so traitors will have to think more carefully if they want to commit to an emag play and encourage using as many of the functionalities as possible, therefore successful emag players making the purchase cost-effective. 
Cost: 6-->8

_Explosive Airlock Charge_, _Dehydrated Carp_
Pure sabotage gear, unfortunately never used as their louder and combat focused cousins were always the reliable and more useful buys. Now, with the removal of the murderbone rule, this buff will go along well with it, as sabotage and creative/challenging murder is always more fun to play against when being non antag. 
Charge cost: 5-->2
Carp cost: 3-->1

_Chameleon Projector_
Another forgotten item with potential, giving it some love to encourage more creative/high moment plays and jukes for tators. 
Cost: 7-->3

_Hacked AI board_
A high risk-high reward item by definition, it often left traitors sad when they went through hell to hack the AI only to get rolled over because you forgot a comma somewhere and then the AI screwed over you. Buffing to help the evil dudes have a fallback strategy in case they failed their subversion. 
Cost: 14-->8 (pretty big ik) 

_Zombie Implant_
An item that requires you to die easily screams "niche" to anyone. 12 TC was simply too oppressive for something that just helped you trick people, a trick that often fails since when you get caught you are rarely able to do anything after you come back to life. 
Cost: 12-->7

_Detomatrix Cartridge_
The only syndie item that has a potentially-devastating drawback. A potential meh stun, at the risk of screwing over yourself. Buffing to help tators a bit when your detomatrix blows on you at first use and RNG hates you. 
Cost: 6-->4

**Nuke ops**

_Main gun option_
Nukies can now choose from 3 sister weapons for the role of their main ranged gun, as their costs are now equal!
C20r (more stuns, lowest damage of all 3)
Cost: 14-->15

Carbine (little stuns, good destruction/damage power) Cost: 18-->15

Chemsprayer (high risk high reward-potentially devastating but can also screw you over or your teammates!)
Cost: 20-->15

(Overall decrease here due to the emag cost nerf)

_Viscerator grenade_
A bit weak compared to the other mandatory nuke op items like adrenals or emags, so consolidating the position of the general AoE gadget. Viscerators are easy to kill, so they will usually just buy the redsuits a bit more time. 
Cost: 8-->6

_Flamethrower_
A less potent main weapon option, you can now buy it if you feel like saving up for something else. 
Cost: 11-->7

_Mauler_
I have never seen it used personally, what's the point of it being powerful if the cost scares everyone away? Maybe this will incentivize players to buy this for like the first time ever? Not to mention mechs are generally weak against multiple hostiles (exactly what the nuke ops are facing) 
Cost: 140-->130

That's it, it took me forever to write this. Comment! 

EDIT: costs updated based on feedback
C20r: 15-->13 (live value: 14) (the carbine is once again more expensive) 
Hacked upload module: 8-->9 (live value: 14)
Emag: 8-->9 (live value: 6)
Storage implant: 8-->9 (live value: 8) 
Chameleon Projector: 3-->5 (live value: 7)

Update 2:
Storage implant: 9-->11 (live value:8)
