### PR TITLE
Drone passing through door fixes (+drone toolbox tweaks)

### DIFF
--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -85,8 +85,11 @@
 	layer = 4
 
 /obj/structure/plasticflaps/CanPass(atom/movable/A, turf/T)
-	if(istype(A) && A.checkpass(PASSGLASS))
-		return prob(60)
+	if(istype(A))
+		if(A.checkpass(PASSDOOR))
+			return 1
+		else if(A.checkpass(PASSGLASS))
+			return prob(60)
 
 	var/obj/structure/stool/bed/B = A
 	if (istype(A, /obj/structure/stool/bed) && (B.buckled_mob || B.density))//if it's a bed/chair and is dense or someone is buckled, it will not pass

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -143,7 +143,7 @@
 	flags = ON_BORDER
 
 /obj/machinery/door/firedoor/border_only/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSDOOR) || mover.checkpass(PASSGLASS)))
 		return 1
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density
@@ -151,7 +151,7 @@
 		return 1
 
 /obj/machinery/door/firedoor/border_only/CheckExit(atom/movable/mover as mob|obj, turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSDOOR) || mover.checkpass(PASSGLASS)))
 		return 1
 	if(get_dir(loc, target) == dir)
 		return !density

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -74,7 +74,7 @@
 	return
 
 /obj/machinery/door/window/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && (mover.checkpass(PASSGLASS) || mover.checkpass(PASSDOOR)))
+	if(istype(mover) && (mover.checkpass(PASSDOOR) || mover.checkpass(PASSGLASS)))
 		return 1
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density
@@ -92,7 +92,7 @@
 	return !density || (dir != to_dir) || check_access(ID)
 
 /obj/machinery/door/window/CheckExit(atom/movable/mover as mob|obj, turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSDOOR) || mover.checkpass(PASSGLASS)))
 		return 1
 	if(get_dir(loc, target) == dir)
 		return !density

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -86,12 +86,15 @@
 	new /obj/item/clothing/gloves/combat(src)
 
 /obj/item/weapon/storage/toolbox/drone
-	name = "mechanical toolbox"
+	name = "drone internal toolbox"
 	icon_state = "blue"
 	item_state = "toolbox_blue"
+	storage_slots = 10
+	max_combined_w_class = 20
 
 /obj/item/weapon/storage/toolbox/drone/New()
 	..()
+	flags |= NODROP
 	var/color = pick("red","yellow","green","blue","pink","orange","cyan","white")
 	new /obj/item/weapon/screwdriver(src)
 	new /obj/item/weapon/wrench(src)
@@ -100,3 +103,4 @@
 	new /obj/item/stack/cable_coil(src,30,color)
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/multitool(src)
+	new /obj/item/weapon/extinguisher/mini(src)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -46,7 +46,7 @@
 	icon_state = "[facing]_[secure ? "secure_" : ""]windoor_assembly[state]"
 
 /obj/structure/windoor_assembly/CanPass(atom/movable/mover, turf/target, height=0)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSDOOR) || mover.checkpass(PASSGLASS)))
 		return 1
 	if(get_dir(loc, target) == dir) //Make sure looking at appropriate border
 		return !density
@@ -60,7 +60,7 @@
 		return 1
 
 /obj/structure/windoor_assembly/CheckExit(atom/movable/mover as mob|obj, turf/target)
-	if(istype(mover) && mover.checkpass(PASSGLASS))
+	if(istype(mover) && (mover.checkpass(PASSDOOR) || mover.checkpass(PASSGLASS)))
 		return 1
 	if(get_dir(loc, target) == dir)
 		return !density

--- a/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/interaction.dm
@@ -81,7 +81,7 @@
 			user << "<span class='warning'>[src] is buckled to the [buckled.name] and cannot be picked up!</span>"
 			return
 		user << "You start picking up the [src]."
-		if(!do_after(user, 20, target = user))
+		if(!do_after(user, 20, target = src))
 			user << "You failed picking up [src]."
 			return
 		user << "<span class='notice'>You pick [src] up.</span>"

--- a/html/changelogs/xthedark-WindoorFix.yml
+++ b/html/changelogs/xthedark-WindoorFix.yml
@@ -12,3 +12,4 @@ delete-after: True
 changes: 
   - tweak: "Drones can now pass through Window Doors from both sides. They can also pass through Plastic Flaps and Firedoors (the ones that drop down during a fire)."
   - rscadd: "Drone toolbox now has an 10 slots, one of which occupied by a pocket fire extinguisher (giving you 2 spare slots). The drone toolbox is not droppable anymore, though."
+  - bugfix: "Drones are no longer picked up despite moving away from the person attempting the pickup."

--- a/html/changelogs/xthedark-WindoorFix.yml
+++ b/html/changelogs/xthedark-WindoorFix.yml
@@ -1,0 +1,14 @@
+# Your name.  
+author: xthedark
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Drones can now pass through Window Doors from both sides. They can also pass through Plastic Flaps and Firedoors (the ones that drop down during a fire)."
+  - rscadd: "Drone toolbox now has an 10 slots, one of which occupied by a pocket fire extinguisher (giving you 2 spare slots). The drone toolbox is not droppable anymore, though."


### PR DESCRIPTION
Refer to issue #801 
Also fixes #817 (might as well, as I'm messing with drones)
### Intent of your Pull Request

Fixes some doors not passing drones through (such as one-way window door thing). Also allows drones to pass through Firedoors (the ones that drop during fire) as well as Plastic Flaps.
- Drone toolbox have 10 slots, it is no longer dropable, though. Max combine weight class changed accordingly.
- Adds a pocket fire extinguisher to the toolbox (meaning 2 slots free).
- Renamed the toolbox to something more telling, now that it's not dropable.
- EDIT: Also fixes the remote drone pick-up bug.
