### PR TITLE
Radiation Crossbow (Radbow)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -151,9 +151,9 @@ var/list/uplink_items = list()
 	surplus = 0
 
 /datum/uplink_item/dangerous/crossbow
-	name = "Miniature Energy Crossbow"
-	desc = "A short bow mounted across a tiller in miniature. Small enough to fit into a pocket or slip into a bag unnoticed. It fires bolts tipped with a paralyzing toxin collected from a rare organism. \
-	The bow generates bolts using an internal power source but must be manually charged between shots."
+	name = "Miniature Radiation Crossbow"
+	desc = "A short bow mounted across a tiller in miniature. Small enough to fit into a pocket or slip into a bag unnoticed. It fires bolts tipped with a powerful toxin collected from a rare organism. \
+	The bow generates bolts using an internal power source and automatically prepares a new shot after cooling down."
 	item = /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow
 	cost = 12
 	excludefrom = list(/datum/game_mode/nuclear,/datum/game_mode/gang)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -136,32 +136,24 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
 	cell_type = "/obj/item/weapon/stock_parts/cell/emproof"
 	needs_permit = 0 // Aparently these are safe to carry? I'm sure Golliaths would disagree.
-	var/overheat = 0
 	var/overheat_time = 16
-	var/recent_reload = 1
 	unique_rename = 1
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/shoot_live_shot()
-	overheat = 1
-	spawn(overheat_time)
-		overheat = 0
-		recent_reload = 0
 	..()
+	spawn(overheat_time)
+		reload()
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/emp_act(severity)
 	return
 
-/obj/item/weapon/gun/energy/kinetic_accelerator/attack_self(mob/living/user)
-	if(overheat || recent_reload)
-		return
+/obj/item/weapon/gun/energy/kinetic_accelerator/proc/reload()
 	power_supply.give(500)
 	if(!suppressed)
 		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)
 	else
-		user << "<span class='warning'>You silently charge [src].<span>"
-	recent_reload = 1
+		loc << "<span class='warning'>[src] silently charges up.<span>"
 	update_icon()
-	return
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/update_icon()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]
@@ -171,7 +163,7 @@
 		icon_state = initial(icon_state)
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/crossbow
-	name = "mini energy crossbow"
+	name = "mini radiation crossbow"
 	desc = "A weapon favored by syndicate stealth specialists."
 	icon_state = "crossbow"
 	item_state = "crossbow"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -131,8 +131,8 @@
 	damage = 20
 	damage_type = TOX
 	nodamage = 0
-	irradiate = 30
-	stun = 1
+	irradiate = 35
+	stun = 2
 	stutter = 5
 
 /obj/item/projectile/energy/bolt/large

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -128,10 +128,11 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 20
 	damage_type = TOX
 	nodamage = 0
-	weaken = 5
+	irradiate = 30
+	stun = 1
 	stutter = 5
 
 /obj/item/projectile/energy/bolt/large

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -125,15 +125,21 @@
 	weaken = 5
 	range = 7
 
-/obj/item/projectile/energy/bolt //ebow bolts
+/obj/item/projectile/energy/bolt//ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
 	damage = 20
 	damage_type = TOX
 	nodamage = 0
 	irradiate = 35
-	stun = 2
+	stun = 1
 	stutter = 5
+
+/obj/item/projectile/energy/bolt/on_hit(target, blocked = 0)
+	..()
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		C.confused = 3
 
 /obj/item/projectile/energy/bolt/large
 	damage = 20

--- a/html/changelogs/ShadowDeath6- Radbows.yml
+++ b/html/changelogs/ShadowDeath6- Radbows.yml
@@ -1,0 +1,8 @@
+ 
+author: ShadowDeath6
+
+delete-after: True
+
+changes: 
+  - rscadd: "Kinetic accelerators and forms of the energy crossbow now automatically recharge."
+  - tweak: "Syndicate weapon designers have tweaked the energy crossbow to now deal more damage on its own, making it much more lethal. However, this change has caused its paralyzing capabilities to be much weaker."


### PR DESCRIPTION
Refer to issue #835 .
### Intent of your Pull Request

The tweak that nobody asked for.

Ports https://github.com/tgstation/-tg-station/pull/15213 by @xxalpha, which makes energy crossbows and kinetic accelerators automatically recharge.

Changes damage on ebows, causing it to actually do a good amount of damage as an actual weapon. 

However, it loses its 5 tick weaken in replacement for a 1 tick stun, which is effectively a disarm. 
Combo cafe is officially kill.

Hopefully this isn't wildly overpowered due to its rad damage, but people actually start collapsing from it at around 4 hits, which seems balanced enough. 

Also renames "mini energy crossbow" to "mini radiation crossbow" and fixes description accordingly.
