### PR TITLE
Ruins Roundstart Radio Runtime

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -217,7 +217,10 @@
 	add_fingerprint(usr)
 
 /obj/item/device/radio/proc/isWireCut(index)
-	return wires.IsIndexCut(index)
+	if(wires)
+		return wires.IsIndexCut(index)
+	else
+		return 1
 
 /obj/item/device/radio/talk_into(atom/movable/M, message, channel, list/spans)
 	if(!on) return // the device has to be on


### PR DESCRIPTION
### Intent of your Pull Request

Fixes a runtime at roundstart caused by radio wires not being initialized yet. It used to only happen occasionally when Poly talked early in the round, but now it happens all the time if at least one person spawns in as a head, and it makes searching for runtimes while bugtesting very annoying.
