### PR TITLE
Abductor Baton Sprite Fixes

### DIFF
--- a/code/game/gamemodes/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/abduction/abduction_gear.dm
@@ -363,7 +363,7 @@ Congratulations! You are now trained for xenobiology research!"}
 	var/mode = BATON_STUN
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "wonderprodStun"
-	item_state = "wonderprod"
+	item_state = "wonderprodStun"
 	slot_flags = SLOT_BELT
 	origin_tech = "materials=6;combat=5;biotech=7"
 	force = 7
@@ -437,6 +437,8 @@ Congratulations! You are now trained for xenobiology research!"}
 
 /obj/item/weapon/abductor_baton/attack_self(mob/living/user)
 	toggle(user)
+	user.update_inv_l_hand()
+	user.update_inv_r_hand()
 
 /obj/item/weapon/abductor_baton/proc/StunAttack(mob/living/L,mob/living/user)
 	user.lastattacked = L

--- a/html/changelogs/Cruix-abductor_baton.yml
+++ b/html/changelogs/Cruix-abductor_baton.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - bugfix: "The abductor baton now starts with the correct inhands sprite, and the sprite is changed properly when the baton is toggled with the action button."


### PR DESCRIPTION
Fixes #833
### Intent of your Pull Request

Fixes the abductor baton spawning with the wrong inhands sprite, and the inhands sprite not changing when toggled with the action button.
