### PR TITLE
Abductor mode bugfixes and improvements

### DIFF
--- a/code/game/gamemodes/abduction/traitor_abd.dm
+++ b/code/game/gamemodes/abduction/traitor_abd.dm
@@ -32,6 +32,8 @@
 	return 1
 
 /datum/game_mode/traitor/abduction/pre_setup()
+	if(!..())
+		return 0
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
@@ -39,6 +41,9 @@
 		restricted_jobs += "Assistant"
 
 	possible_abductors = get_players_for_role(BE_ABDUCTOR)
+	for(var/datum/mind/M in possible_abductors)
+		if(M.special_role)
+			possible_abductors -= M
 
 	abductor_teams = max(1, min(max_teams,round(num_players()/config.abductor_scaling_coeff)))
 	var/possible_teams = max(1,round(possible_abductors.len / 2))
@@ -56,19 +61,22 @@
 		for(var/i=1,i<=abductor_teams,i++)
 			if(availible_subjects < 6)
 				//message_admins("Less abductor teams than expected were created because there were not enough test subjects.")
-				return ..() //Run out of valid abductors
+				return 1 //Run out of valid abductors
 			availible_subjects -= 6 // Number to abduct
 			if(!make_abductor_team(i))
 				//message_admins("<B>Could not start mode Traitor+Abductor: Not enough players to form an abductor team.  You should never see this.</B>")
 				return 0
-		return ..()
+		return 1
 	else
 		//message_admins("<B>Could not start mode Traitor+Abductor: Not enough players with BE_ABDUCTOR.</B>")
 		return 0
 
 /datum/game_mode/traitor/abduction/proc/make_abductor_team(team_number,preset_agent=null,preset_scientist=null)
 	//Team Name
-	team_names[team_number] = "Mothership [pick(possible_changeling_IDs)]" //TODO Ensure unique and actual alieny names
+	var/list/possible_abd_team_names = list("Alpha","Beta","Delta","Gamma","Epsilon","Phi")
+	var/tname = pick(possible_abd_team_names)
+	possible_abd_team_names -= tname
+	team_names[team_number] = "Mothership [tname]"
 	//Team Objective
 	var/datum/objective/experiment/team_objective = new
 	team_objective.team = team_number

--- a/code/game/gamemodes/abduction/traitor_abd_ling.dm
+++ b/code/game/gamemodes/abduction/traitor_abd_ling.dm
@@ -28,6 +28,8 @@
 	return 1
 
 /datum/game_mode/traitor/abduction/changeling/pre_setup()
+	if(!..())
+		return 0
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
@@ -35,6 +37,9 @@
 		restricted_jobs += "Assistant"
 
 	var/list/datum/mind/possible_changelings = get_players_for_role(BE_CHANGELING)
+	for(var/datum/mind/cling in possible_changelings)
+		if(cling.special_role == "abductor scientist" || cling.special_role == "abductor_agent")
+			possible_changelings -= cling
 
 	var/num_changelings = 1
 
@@ -51,7 +56,7 @@
 			changelings += changeling
 			modePlayer += changelings
 			changeling.restricted_roles = restricted_jobs
-		return ..()
+		return 1
 	else
 		return 0
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -6,6 +6,7 @@
 	var/completed = 0					//currently only used for custom objectives.
 	var/dangerrating = 0				//How hard the objective is, essentially. Used for dishing out objectives and checking overall victory.
 	var/martyr_compatible = 0			//If the objective is compatible with martyr objective, i.e. if you can still do it while dead.
+	var/list/restricted_special_roles = list()  //Special roles that the objective cannot refer to.
 
 /datum/objective/New(var/text)
 	if(text)
@@ -28,6 +29,11 @@
 	for(var/datum/mind/possible_target in ticker.minds)
 		if(possible_target != owner && ishuman(possible_target.current) && (possible_target.current.stat != 2) && is_unique_objective(possible_target))
 			possible_targets += possible_target
+	if(restricted_special_roles.len && possible_targets.len)
+		for(var/R in restricted_special_roles)
+			for(var/datum/mind/T in possible_targets)
+				if(T.special_role == R)
+					possible_targets -= T
 	if(possible_targets.len > 0)
 		target = pick(possible_targets)
 	update_explanation_text()
@@ -67,6 +73,7 @@
 	var/target_role_type=0
 	dangerrating = 10
 	martyr_compatible = 1
+	restricted_special_roles = list("abductor agent","abductor scientist")
 
 /datum/objective/assassinate/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
@@ -95,6 +102,7 @@
 /datum/objective/mutiny
 	var/target_role_type=0
 	martyr_compatible = 1
+	restricted_special_roles = list("abductor agent","abductor scientist")
 
 /datum/objective/mutiny/find_target_by_role(role, role_type=0,invert=0)
 	if(!invert)
@@ -128,6 +136,7 @@
 	var/target_role_type=0
 	dangerrating = 5
 	martyr_compatible = 1
+	restricted_special_roles = list("abductor agent","abductor scientist")
 
 /datum/objective/maroon/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
@@ -157,6 +166,7 @@
 /datum/objective/debrain//I want braaaainssss
 	var/target_role_type=0
 	dangerrating = 20
+	restricted_special_roles = list("abductor agent","abductor scientist")
 
 /datum/objective/debrain/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
@@ -194,6 +204,7 @@
 	var/target_role_type=0
 	dangerrating = 10
 	martyr_compatible = 1
+	restricted_special_roles = list("abductor agent","abductor scientist")
 
 /datum/objective/protect/find_target_by_role(role, role_type=0, invert=0)
 	if(!invert)
@@ -340,6 +351,7 @@
 	dangerrating = 10
 	var/target_real_name // Has to be stored because the target's real_name can change over the course of the round
 	var/target_missing_id
+	restricted_special_roles = list("abductor agent","abductor scientist")
 
 /datum/objective/escape/escape_with_identity/find_target()
 	target = ..()

--- a/html/changelogs/MacHac-AbductorBugfixes.yml
+++ b/html/changelogs/MacHac-AbductorBugfixes.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MacHac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Abductors can no longer be traitors."
+  - bugfix: "Abductor teams will now have unique names."
+  - bugfix: "Traitors and changelings will no longer get objectives to assassinate abductors."

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -655,7 +655,6 @@
 #include "code\game\objects\items\stacks\sheets\mineral.dm"
 #include "code\game\objects\items\stacks\sheets\sheet_types.dm"
 #include "code\game\objects\items\stacks\sheets\sheets.dm"
-
 #include "code\game\objects\items\stacks\tiles\light.dm"
 #include "code\game\objects\items\stacks\tiles\tile_mineral.dm"
 #include "code\game\objects\items\stacks\tiles\tile_types.dm"


### PR DESCRIPTION
### Intent of Pull Request

This PR adds a few bugfixes and QoL improvements related to the traitor+abductor(+ling) mode.
- Abductors can no longer spawn as both and abductor and a traitor (or changeling)
- Traitors and changelings will no longer have objectives to assassinate or maroon abductors
- Abductor teams will now have unique names
