### PR TITLE
Adds random event for frying APCs.

### DIFF
--- a/code/modules/events/apc_fry.dm
+++ b/code/modules/events/apc_fry.dm
@@ -1,0 +1,24 @@
+/datum/round_event_control/apc_fry
+	name = "Fried APCs"
+	typepath = /datum/round_event/apc_fry
+	weight = 70
+	earliest_start = 1000
+
+/datum/round_event/apc_fry
+	announceWhen = 15
+	var/fry_chance = 3
+
+/datum/round_event/apc_fry/setup()
+	startWhen = rand(15, 25)
+	fry_chance = rand(2,5) //2 to 5 percent of station APCs get fuck'd.
+	announceWhen = startWhen + 5
+
+/datum/round_event/apc_fry/announce()
+	if(prob(30))
+		priority_announce("Error Detected in the Station Electrical Grid. Malfunctioning area power controllers may follow.", "Power Grid")
+	else
+		message_admins("The 'Fried APC' event has fired, but the crew has not been alerted. If you are confused, this is why.")
+/datum/round_event/apc_fry/start()
+	for(var/obj/machinery/power/apc/A in world)
+		if(prob(fry_chance))
+			A.break_apc()

--- a/code/modules/events/apc_fry.dm
+++ b/code/modules/events/apc_fry.dm
@@ -15,7 +15,7 @@
 
 /datum/round_event/apc_fry/announce()
 	if(prob(30))
-		priority_announce("Error Detected in the Station Electrical Grid. Malfunctioning area power controllers may follow.", "Power Grid")
+		priority_announce("Error detected in the station electrical grid. Malfunctioning area power controllers may follow.", "Power Grid")
 	else
 		message_admins("The 'Fried APC' event has fired, but the crew has not been alerted. If you are confused, this is why.")
 /datum/round_event/apc_fry/start()

--- a/code/modules/events/apc_fry.dm
+++ b/code/modules/events/apc_fry.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/apc_fry
 	name = "Fried APCs"
 	typepath = /datum/round_event/apc_fry
-	weight = 70
+	weight = 45
 	earliest_start = 1000
 
 /datum/round_event/apc_fry
@@ -18,6 +18,7 @@
 		priority_announce("Error detected in the station electrical grid. Malfunctioning area power controllers may follow.", "Power Grid")
 	else
 		message_admins("The 'Fried APC' event has fired, but the crew has not been alerted. If you are confused, this is why.")
+
 /datum/round_event/apc_fry/start()
 	for(var/obj/machinery/power/apc/A in world)
 		if(prob(fry_chance))

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -590,6 +590,21 @@
 			user << "<span class='notice'>You emag the APC interface.</span>"
 			update_icon()
 
+/obj/machinery/power/apc/proc/break_apc()
+	if(!emagged && !malfhack)
+		if(opened)
+			return
+		if(wiresexposed)
+			return
+		if(stat & (BROKEN|MAINT))
+			return
+		flick("apc-spark", src)
+		for(var/mob/O in viewers(src))
+			O << "<span class='warning'>The [src] makes crackling noises and puffs of smoke rise from it.</span>"
+		emagged = 1
+		locked = 0
+		update_icon()
+
 // attack with hand - remove cell (if cover open) or interact with the APC
 
 /obj/machinery/power/apc/attack_hand(mob/user)

--- a/html/changelogs/AsV9-FriedAPC.yml
+++ b/html/changelogs/AsV9-FriedAPC.yml
@@ -1,0 +1,7 @@
+author: AsV9
+
+delete-after: True
+
+changes:
+  - rscadd: "APCs can now malfunction randomly. Yes. This means every single APC. And you will only know for sure 30% of the time."
+

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1000,6 +1000,7 @@
 #include "code\modules\events\anomaly_grav.dm"
 #include "code\modules\events\anomaly_pyro.dm"
 #include "code\modules\events\anomaly_vortex.dm"
+#include "code\modules\events\apc_fry.dm"
 #include "code\modules\events\blob.dm"
 #include "code\modules\events\borer.dm"
 #include "code\modules\events\brand_intelligence.dm"


### PR DESCRIPTION
I really wanted to add increased chances for AI core and AI upload..

I somehow resisted my temptations.
### How this shit works:

Random event fires.
This can happen pretty early in the round. Like almost at roundstart.

A random roll is done in the range 2 to 5. This decides the percentage of all APCs on the station gets fried.

Somewhere between 15 and 25 seconds after that, the actual thing happens.

5 seconds after that, a random roll is done to find out if we should alert the crew. This is currently set to 30% of the time.

If we alert the crew, a big message telling everyone appears.
If not, the admins are alerted, so they don't get confused.
