### PR TITLE
Security Barriers will report how much health they have left

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -326,20 +326,22 @@ for reference:
 
 			var/damagereport
 			if(W.force <= 5 && W.force != 0) // less or equal to 5
-				damagereport = "a small amount of damage from an external source"
+				damagereport = "a small amount of damage."
 			if(W.force > 5 && W.force <= 15) // in the 5-15 range, but greater than 5
-				damagereport = "a moderate amount of damage from an external source"
+				damagereport = "a moderate amount of damage."
 			if(W.force > 15) //greater than 15
-				damagereport = "a large amount of damage from an external source"
+				damagereport = "a large amount of damage."
+			else if (!damagereport)
+				return
 
 			if(src.health <= 95 && src.health > 50)
-				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] in a sufficient state!!",radio_freq)
+				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] The barriers rate of functionality is at [health]%!!",radio_freq)
 
 			if(src.health <= 50 && src.health > 25)
-				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] while they are in need of dire repair!!",radio_freq)
+				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] The barriers rate of functionality is at [health]%!!",radio_freq)
 
 			if(src.health <= 25 && src.health > 0)
-				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] at a currently fatal state!!",radio_freq)
+				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] The barriers rate of functionality is at [health]%!!",radio_freq)
 
 
 /obj/machinery/deployable/barrier/proc/desc_report() // something to update the description of the barrier.

--- a/html/changelogs/Super3222-BarrierTweak.yml
+++ b/html/changelogs/Super3222-BarrierTweak.yml
@@ -1,0 +1,13 @@
+# Your name.  
+author: Super3222
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Nanotrasen has upgraded their security barriers for their beloved security team. The barrier's damage report will include how much health they have remaining."


### PR DESCRIPTION
### Intent of your Pull Request

Simple tweak. Security barriers will report how much health they have when taking damage. This will only work if you have secured an encryption key into them.

Also fixes a small, but possible bug. Barriers will no longer report damage when something that does 0 damage hits them.

This will not make security "OP". Remember these are GIANT barriers meant to keep things/places safe and completely secure.

Also emags still currently disable radio signals from leaving a barrier, so that's a pretty good counter.
