### PR TITLE
Small fixes to revenant from /tg/

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -80,13 +80,7 @@
 		AltClickOn(A)
 		return
 	if(modifiers["ctrl"])
-		if(istype(A, /mob/living))
-			var/mob/living/LM = A
-			var/list/targets = list()
-			targets += LM
-			revtransmit.cast(targets)
-		else
-			CtrlClickOn(A)
+		CtrlClickOn(A)
 		return
 
 	if(world.time <= next_move)
@@ -95,6 +89,13 @@
 	if(ishuman(A) && in_range(src, A))
 		Harvest(A)
 
+/mob/living/simple_animal/revenant/CtrlClickOn(atom/A, params) //Copypaste from ghost code - revenants can't interact with the world directly.
+	if(istype(A, /mob/living))
+		var/mob/living/LM = A
+		var/list/targets = list()
+		targets += LM
+		revtransmit.cast(targets)
+	..()
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 	if(!castcheck(0))

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -44,7 +44,6 @@
 	var/list/drained_mobs = list() //Cannot harvest the same mob twice
 
 /mob/living/simple_animal/revenant/Life()
-	..()
 	if(essence < essence_min)
 		essence = essence_min
 	if(essence_regenerating && !inhibited && essence < essence_regen_cap) //While inhibited, essence will not regenerate
@@ -54,6 +53,7 @@
 	maxHealth = essence * 3
 	if(!revealed)
 		health = maxHealth //Heals to full when not revealed
+	..()
 
 /mob/living/simple_animal/revenant/ex_act(severity, target)
 	return 1 //Immune to the effects of explosions.
@@ -200,6 +200,8 @@
 	return 0
 
 /mob/living/simple_animal/revenant/death()
+	if(!revealed || stat == DEAD)
+		return 0
 	..(1)
 	src << "<span class='userdanger'><b>NO! No... it's too late, you can feel yourself fading...</b></span>"
 	notransform = 1
@@ -209,7 +211,7 @@
 	visible_message("<span class='warning'>[src] lets out a waning screech as violet mist swirls around its dissolving body!</span>")
 	icon_state = "revenant_draining"
 	for(var/i = alpha, i > 0, i -= 10)
-		sleep(0.1)
+		stoplag()
 		alpha = i
 	visible_message("<span class='danger'>[src]'s body breaks apart into blue dust.</span>")
 	new /obj/item/weapon/ectoplasm/revenant(get_turf(src))

--- a/code/modules/mob/living/simple_animal/revenant/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant/revenant.dm
@@ -42,6 +42,8 @@
 	var/essence_drained = 0 //How much essence the revenant has drained.
 	var/draining = 0 //If the revenant is draining someone.
 	var/list/drained_mobs = list() //Cannot harvest the same mob twice
+	
+	var/obj/effect/proc_holder/spell/targeted/revenant_transmit/revtransmit //Need to keep this here to allow revenant to "quick cast" transmit via Ctrl+Click
 
 /mob/living/simple_animal/revenant/Life()
 	if(essence < essence_min)
@@ -52,7 +54,8 @@
 			essence = essence_regen_cap
 	maxHealth = essence * 3
 	if(!revealed)
-		health = maxHealth //Heals to full when not revealed
+		if(health < maxHealth) //Heals to full when not revealed
+			heal_overall_damage(getBruteLoss(),getFireLoss())
 	..()
 
 /mob/living/simple_animal/revenant/ex_act(severity, target)
@@ -77,7 +80,13 @@
 		AltClickOn(A)
 		return
 	if(modifiers["ctrl"])
-		CtrlClickOn(A)
+		if(istype(A, /mob/living))
+			var/mob/living/LM = A
+			var/list/targets = list()
+			targets += LM
+			revtransmit.cast(targets)
+		else
+			CtrlClickOn(A)
 		return
 
 	if(world.time <= next_move)
@@ -192,7 +201,9 @@
 
 /mob/living/simple_animal/revenant/proc/giveSpells()
 	if(src.mind)
-		src.mind.spell_list += new /obj/effect/proc_holder/spell/targeted/revenant_transmit
+		var/obj/effect/proc_holder/spell/targeted/revenant_transmit/RT = new
+		revtransmit = RT
+		src.mind.spell_list += RT
 		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_light
 		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_defile
 		src.mind.spell_list += new /obj/effect/proc_holder/spell/aoe_turf/revenant_malf

--- a/html/changelogs/Xthedark-revenant_death_fix.yml
+++ b/html/changelogs/Xthedark-revenant_death_fix.yml
@@ -3,4 +3,6 @@ author: XTheDark
 delete-after: True
 
 changes: 
-  - bugfix: "Hopefully fixes revenants spontantaniously combusting for no reason."
+  - bugfix: "Fixes revenants dieing randomly."
+  - bugfix: "Conceiled revenants are no longer shot by turrets."
+  - rscadd: "Revenants can now Transmit to someone using Control+Click."

--- a/html/changelogs/Xthedark-revenant_death_fix.yml
+++ b/html/changelogs/Xthedark-revenant_death_fix.yml
@@ -1,0 +1,6 @@
+author: XTheDark
+
+delete-after: True
+
+changes: 
+  - bugfix: "Hopefully fixes revenants spontantaniously combusting for no reason."


### PR DESCRIPTION
Refer to issue #664 
All it takes is for a coder's fun to be ruined for that said coder to become motivated to fix the issue as soon as possible...go figure.
### Intent of your Pull Request

Minor port of some small stuff from /tg/, credit to original creators.
Refer to tgstation/-tg-station/pull/11757 by ghost - death() proc no longer triggers on non-revealed revenants.
Not linking because the actual pull from /tg/ touches upon many, many more things.
1. ..() call moved to end of Life()
2. Ported over checks for revenant being revealed or dead for death().
3. Also uses MSO's stoplag() instead of sleep().
4. Definately fixes revenants dieing randomly. **Cause** : Revenants were not healed correctly when not revealed.
5. Revenants can now quick-cast Transmit via Control Click.
6. Turrets no longer target non-revealed revenants.
7. Also sprucens up the turret code by adding calculate_targets() from /tg/

Stuff tested:
- Revenant can still be killed while it is revealed.
- Revenant doesn't die if it buys something after it's been damaged and becomes concealed.
- Quick-casting Transmit.
- Revenants now properly heal brute/fire damage when not revealed.
