### PR TITLE
Lasertag ED209s no longer stun adjacent targets.

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -250,7 +250,7 @@ Auto Patrol[]"},
 				back_to_idle()
 
 			if(target)		// make sure target exists
-				if(Adjacent(target) && isturf(target.loc)) // if right next to perp
+				if(!lasercolor && Adjacent(target) && isturf(target.loc)) // if right next to perp
 					playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 					icon_state = "[lasercolor]ed209-c"
 					spawn(2)

--- a/html/changelogs/cruix-ed209.yml
+++ b/html/changelogs/cruix-ed209.yml
@@ -1,0 +1,6 @@
+author: Cruix
+
+delete-after: True
+
+changes: 
+  - rscadd: "Lasertag ED-209s will no longer stun people who attack them."


### PR DESCRIPTION
Fixes #868 
### Intent of your Pull Request

Lasertag ED209s no longer stun adjacent targets.
