### PR TITLE
Make Rev Tolerable Again

### DIFF
--- a/code/game/gamemodes/revolution/rev_flash.dm
+++ b/code/game/gamemodes/revolution/rev_flash.dm
@@ -1,0 +1,81 @@
+#define REVPEN_COOLDOWN 300
+
+/obj/item/device/flash/rev
+	name = "suspicious device"
+	desc = "You aren't sure what this thing does, but you're almost certain that it can't be good."
+	icon_state = "memorizer"
+	item_state = "nullrod"
+
+	var/cooldown = 0
+
+/obj/item/device/flash/rev/attack(mob/living/M, mob/user)
+	if(!try_use_flash(user))
+		return 0
+
+	if(cooldown)
+		return 0
+
+	if(iscarbon(M))
+		flash_carbon(M, user, 5, 1)
+		return 1
+
+	else if(issilicon(M))
+		add_logs(user, M, "flashed", src)
+		M.flash_eyes(affect_silicon = 1)
+		M.Weaken(rand(5,10))
+		user.visible_message("<span class='disarm'>[user] holds something up to [M]'s sensor bank, and its eyes fall dark!</span>", "<span class='danger'>You overload [M]'s sensors with the device!</span>")
+		return 1
+
+	user.visible_message("<span class='disarm'>[user] tries to hold something up to [M]'s face, but nothing happens!</span>", "<span class='warning'>You fail to convert [M] with the device!</span>")
+
+/obj/item/device/flash/rev/flash_carbon(mob/living/carbon/M, mob/user = null, power = 5, targeted = 1)
+	add_logs(user, M, "flashed", src)
+	var/resisted = 0
+	if(user && targeted)
+		if(M.weakeyes)
+			M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
+		if(M.flash_eyes(1, 1))
+			M.confused += power
+			if(ishuman(M) && ishuman(user) && M.stat != DEAD)
+				if(user.mind && (user.mind in ticker.mode.head_revolutionaries))
+					if(M.client)
+						if(M.stat == CONSCIOUS)
+							M.mind_initialize() //give them a mind datum if they don't have one.
+							if(!isloyal(M))
+								if(user.mind in ticker.mode.head_revolutionaries)
+									if(ticker.mode.add_revolutionary(M.mind))
+										times_used -- //Flashes less likely to burn out for headrevs when used for conversion
+									else
+										resisted = 1
+							else
+								resisted = 1
+
+							if(resisted)
+								user << "<span class='warning'>This mind seems resistant to conversion!</span>"
+						else
+							user << "<span class='warning'>They must be conscious before you can convert them!</span>"
+							return
+					else
+						user << "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>"
+						return
+			M.Stun(1)
+			visible_message("<span class='disarm'>[user] holds something up to [M]'s face!</span>")
+			if(resisted)
+				user << "<span class='danger'>You fail to convert [M] with the device!</span>"
+			else
+				user << "<span class='danger'>You convert [M] to the cause!</span>"
+			M << "<span class='userdanger'>[user] holds something up to your face!</span>"
+			if(M.weakeyes)
+				M.Stun(2)
+				M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shield your eyes!</span>")
+		else
+			visible_message("<span class='disarm'>[user] tries to hold something up to [M]'s face, but fails!</span>")
+			user << "<span class='warning'>You fail to convert [M] with the device!</span>"
+			M << "<span class='danger'>[user] tries to hold something up to your face, but nothing happens!</span>"
+	else
+		if(M.flash_eyes())
+			M.confused += power
+
+	cooldown = 1
+	spawn(REVPEN_COOLDOWN)
+		cooldown = 0

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -126,7 +126,8 @@
 			mob.dna.remove_mutation(CLOWNMUT)
 
 
-	var/obj/item/device/flash/T = new(mob)
+	var/obj/item/device/flash/rev/T = new(mob)
+	var/obj/item/device/revtool/RT = new(mob)
 	var/obj/item/toy/crayon/spraycan/R = new(mob)
 
 	var/list/slots = list (
@@ -138,13 +139,21 @@
 	)
 	var/where = mob.equip_in_one_of_slots(T, slots)
 	mob.equip_in_one_of_slots(R,slots)
+	var/rtwhere = mob.equip_in_one_of_slots(RT, slots)
 
 	mob.update_icons()
 
 	if (!where)
-		mob << "The Syndicate were unfortunately unable to get you a flash."
+		mob << "Unfortunately, due to budget cuts, the syndicate were unable to get you a conversion tool.  Maybe try prayer?"
 	else
-		mob << "The flash in your [where] will help you to persuade the crew to join your cause."
+		mob << "The syndicate have given you a conversion tool in your [where] to help persuade the crew to join your cause."
+
+	if(!rtwhere)
+		mob << "Unfortunately, due to budget cuts, the syndicate were unable to get you a flash hijacker.  Maybe try prayer?"
+	else
+		mob << "The syndicate have also given you a device which can convert regular flashes to conversion tools."
+
+	if(where && rtwhere)
 		return 1
 
 /////////////////////////////////
@@ -410,3 +419,10 @@
 		text += "<br>"
 
 		world << text
+
+/obj/item/device/revtool
+	name = "Electronic Flashbulb Hijacker"
+	desc = "A device designed to reconfigure standard NT issue flashbulbs into something more sinister."
+	icon = 'icons/obj/items.dmi'
+	icon_state = "implanter1"
+	item_state = "syringe_0"

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -56,6 +56,22 @@
 
 	return 1
 
+/obj/item/device/flash/attackby(obj/item/W, mob/user, params)
+	if(broken)
+		user << "<span class='warning'>You cannot do this to a broken flash!</span>"
+		return
+	if(istype(W,/obj/item/device/revtool))
+		if(user.mind && (user.mind in ticker.mode.head_revolutionaries))
+			user << "<span class='warning'>You plug the device into the flash. (This will take about 30 seconds, and you need to stand still!)</span>"
+			if(do_after(user, rand(250,350), target = src))
+				var/obj/item/device/flash/rev/R = new
+				user.unEquip(src)
+				user.put_in_hands(R)
+				user << "<span class='warning'>The flash seems to elongate, and lets out a soft whistle.</span>"
+				qdel(src)
+		else
+			user << "<span class='warning'>You're not sure how to use this!</span>"
+			return
 
 /obj/item/device/flash/proc/flash_carbon(mob/living/carbon/M, mob/user = null, power = 5, targeted = 1)
 	add_logs(user, M, "flashed", src)
@@ -64,14 +80,13 @@
 			M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
 		if(M.flash_eyes(1, 1))
 			M.confused += power
-			terrible_conversion_proc(M, user)
 			M.Stun(1)
 			visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
 			user << "<span class='danger'>You blind [M] with the flash!</span>"
 			M << "<span class='userdanger'>[user] blinds you with the flash!</span>"
 			if(M.weakeyes)
 				M.Stun(2)
-				M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shields your eyes!</span>")
+				M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shield your eyes!</span>")
 		else
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
 			user << "<span class='warning'>You fail to blind [M] with the flash!</span>"
@@ -113,31 +128,6 @@
 		flash_carbon(M, null, 10, 0)
 	burn_out()
 	..()
-
-
-/obj/item/device/flash/proc/terrible_conversion_proc(mob/M, mob/user)
-	if(ishuman(M) && ishuman(user) && M.stat != DEAD)
-		if(user.mind && (user.mind in ticker.mode.head_revolutionaries))
-			if(M.client)
-				if(M.stat == CONSCIOUS)
-					M.mind_initialize() //give them a mind datum if they don't have one.
-					var/resisted
-					if(!isloyal(M))
-						if(user.mind in ticker.mode.head_revolutionaries)
-							if(ticker.mode.add_revolutionary(M.mind))
-								times_used -- //Flashes less likely to burn out for headrevs when used for conversion
-							else
-								resisted = 1
-					else
-						resisted = 1
-
-					if(resisted)
-						user << "<span class='warning'>This mind seems resistant to the flash!</span>"
-				else
-					user << "<span class='warning'>They must be conscious before you can convert them!</span>"
-			else
-				user << "<span class='warning'>This mind is so vacant that it is not susceptible to influence!</span>"
-
 
 /obj/item/device/flash/cyborg
 	origin_tech = null

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -367,6 +367,7 @@
 #include "code\game\gamemodes\nuclear\nuclear_challenge.dm"
 #include "code\game\gamemodes\nuclear\nuclearbomb.dm"
 #include "code\game\gamemodes\nuclear\pinpointer.dm"
+#include "code\game\gamemodes\revolution\rev_flash.dm"
 #include "code\game\gamemodes\revolution\revolution.dm"
 #include "code\game\gamemodes\sandbox\airlock_maker.dm"
 #include "code\game\gamemodes\sandbox\h_sandbox.dm"


### PR DESCRIPTION
Refer to all of the many issues regarding rev.
### Intent of Pull Request

This pull request tweaks how revolutionaries convert people to their cause.
#### CONVERSION TOOLS

Revolutionaries are no longer able to just pick up a flash, flip the switch on the side to 'CONVERT TO NT HATING COMMUNIST', and start zapping away.  Instead, this conversion is done with the use of a conversion tool, or 'Suspicious Device'.  The suspicious device behaves much like a regular flash; However, it looks unique both dropped and in hand.  It also needs time to recharge after converting someone to communism, and will be unusable during this time.
###### But how do revs get more conversion tools?

Head revs now also start with a tool designed to hijack NT flashes and turn them into conversion tools.  This device, when used on a regular flash, will convert it over a period of about thirty seconds.  Note that this process is aborted if the revolutionary moves during this time.
#### BUT WHY
- Revheads can no longer run into a crowded room and have everyone flashed before anyone can react.
- Revheads now have to be at least a little subtle when converting, at least until the revolution gains speed.
- You can now very easily tell the difference between a revhead and someone who has a flash for self defense purposes.
- The fact that most revheads will be carrying around flash hijackers makes it more feasible for staff to find them.
