### PR TITLE
Ports smartfridge fix from /tg/ by MSO

### DIFF
--- a/code/modules/food&drinks/kitchen machinery/smartfridge.dm
+++ b/code/modules/food&drinks/kitchen machinery/smartfridge.dm
@@ -16,7 +16,6 @@
 	var/max_n_of_items = 1500
 	var/icon_on = "smartfridge"
 	var/icon_off = "smartfridge-off"
-	var/list/item_quants = list()
 	var/icon_open = "smartfridge_open"
 	var/icon_closed = "smartfridge"
 
@@ -28,7 +27,6 @@
 	RefreshParts()
 
 /obj/machinery/smartfridge/construction()
-	item_quants.Cut()
 	for(var/datum/A in contents)
 		qdel(A)
 
@@ -136,13 +134,6 @@
 		S.remove_from_storage(O,src)
 
 	O.loc = src
-	var/n = O.name
-
-	if(item_quants[n])
-		item_quants[n]++
-	else
-		item_quants[n] = 1
-	sortList(item_quants)
 
 /obj/machinery/smartfridge/attack_paw(mob/user)
 	return src.attack_hand(user)
@@ -167,23 +158,32 @@
 	if (contents.len == 0)
 		dat += "<font color = 'red'>No product loaded!</font>"
 	else
-		for (var/O in item_quants)
-			if(item_quants[O] > 0)
-				var/N = item_quants[O]
-				var/itemName = sanitize(O)
-				dat += "<FONT color = 'blue'><B>[capitalize(O)]</B>:"
-				dat += " [N] </font>"
-				dat += "<a href='byond://?src=\ref[src];vend=[itemName];amount=1'>Vend</A> "
-				if(N > 5)
-					dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=5'>x5</A>)"
-					if(N > 10)
-						dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=10'>x10</A>)"
-						if(N > 25)
-							dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=25'>x25</A>)"
-				if(N > 1)
-					dat += "(<a href='?src=\ref[src];vend=[itemName];amount=[N]'>All</A>)"
+		var/listofitems = list()
+		for (var/atom/movable/O in contents)
+			if (listofitems[O.name])
+				listofitems[O.name]++
+			else
+				listofitems[O.name] = 1
+		sortList(listofitems)
 
-				dat += "<br>"
+		for (var/O in listofitems)
+			if(listofitems[O] <= 0)
+				continue
+			var/N = listofitems[O]
+			var/itemName = url_encode(O)
+			dat += "<FONT color = 'blue'><B>[capitalize(O)]</B>:"
+			dat += " [N] </font>"
+			dat += "<a href='byond://?src=\ref[src];vend=[itemName];amount=1'>Vend</A> "
+			if(N > 5)
+				dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=5'>x5</A>)"
+				if(N > 10)
+					dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=10'>x10</A>)"
+					if(N > 25)
+						dat += "(<a href='byond://?src=\ref[src];vend=[itemName];amount=25'>x25</A>)"
+			if(N > 1)
+				dat += "(<a href='?src=\ref[src];vend=[itemName];amount=[N]'>All</A>)"
+
+			dat += "<br>"
 
 		dat += "</TT>"
 	user << browse("<HEAD><TITLE>[src] supplies</TITLE></HEAD><TT>[dat]</TT>", "window=smartfridge")
@@ -198,21 +198,14 @@
 	var/N = href_list["vend"]
 	var/amount = text2num(href_list["amount"])
 
-	if(item_quants[N] <= 0) // Sanity check, there are probably ways to press the button when it shouldn't be possible.
-		return
-
-	item_quants[N] = max(item_quants[N] - amount, 0)
-
 	var/i = amount
 	for(var/obj/O in contents)
+		if(i <= 0)
+			break
 		if(O.name == N)
 			O.loc = src.loc
 			i--
-			if(i <= 0)
-				break
-
-	src.updateUsrDialog()
-	return
+	updateUsrDialog()
 
 
 // ----------------------------

--- a/html/changelogs/xthedark-smartfridge_fix.yml
+++ b/html/changelogs/xthedark-smartfridge_fix.yml
@@ -1,0 +1,6 @@
+author: xthedark
+
+delete-after: True
+
+changes: 
+  - bugfix: "(Ported from /tg/, credit to MrStonedOne) Smarfridges work with apostrophed/ampersanted names correctly."


### PR DESCRIPTION
Refer to issue #921 .
### Intent of your Pull Request

Of course, /tg/ already fixed this in their code ages ago. Ported over from https://github.com/tgstation/-tg-station/pull/12944 by MrStonedOne.

Tested:
- Medical Smartfridge accepts/vends everything even if it's named like crap.
- Xenobiology Smartfridge vends/accepts slimes cores (basic functionality not broken, in case there are some bizzare differences between our and /tg/s code)
- Botany Smartfridge vends/accepts items (see above)
