### PR TITLE
Revhead Latejoin Icon Fix

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -190,6 +190,8 @@
 			equip_revolutionary(stalin.current)
 			forge_revolutionary_objectives(stalin)
 			greet_revolutionary(stalin)
+			update_rev_icons_removed(stalin)
+			update_rev_icons_added(stalin)
 
 //////////////////////////////////////
 //Checks if the revs have won or not//


### PR DESCRIPTION
### Intent of your Pull Request

Revolutionaries automatically made revheads midway through the round now have their rev icons properly updated.
