### PR TITLE
Shunting no longer adds 30 seconds to nuke timer.

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -900,12 +900,13 @@
 	if (seclevel2num(get_security_level()) == SEC_LEVEL_DELTA)
 		for(var/obj/item/weapon/pinpointer/point in world)
 			point.the_disk = src //the pinpointer will detect the shunted AI
-
-	/*if(malf.nuking == TRUE)
+	/*
+	if(malf.nuking == TRUE)
 		for(var/obj/machinery/doomsday_device/D in world)
 			if(D.timer > 0) //well we don't want to do this if the timeleft is 0 duh.
 				D.timer += 30 //add 30 seconds to nuke timer.
-				//I was going to add 60 seconds to that thing above. but I realized I was dealing with BYOND seconds which are twice as long.*/
+				//I was going to add 60 seconds to that thing above. but I realized I was dealing with BYOND seconds which are twice as long.
+	*/
 
 /obj/machinery/power/apc/proc/malfvacate(forced)
 	if(!src.occupier)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -901,11 +901,11 @@
 		for(var/obj/item/weapon/pinpointer/point in world)
 			point.the_disk = src //the pinpointer will detect the shunted AI
 
-	if(malf.nuking == TRUE)
+	/*if(malf.nuking == TRUE)
 		for(var/obj/machinery/doomsday_device/D in world)
 			if(D.timer > 0) //well we don't want to do this if the timeleft is 0 duh.
 				D.timer += 30 //add 30 seconds to nuke timer.
-				//I was going to add 60 seconds to that thing above. but I realized I was dealing with BYOND seconds which are twice as long.
+				//I was going to add 60 seconds to that thing above. but I realized I was dealing with BYOND seconds which are twice as long.*/
 
 /obj/machinery/power/apc/proc/malfvacate(forced)
 	if(!src.occupier)

--- a/html/changelogs/AsV9-malfnuketweak.yml
+++ b/html/changelogs/AsV9-malfnuketweak.yml
@@ -1,0 +1,6 @@
+author: AsV9
+
+delete-after: True
+
+changes: 
+  - tweak: "Shunting no longer adds 30 seconds to malf nuke timer."


### PR DESCRIPTION
Because it made getting the nuke so fucking difficult and/or made shunting basically useless.
The nuke is tied to the AI core itself so if that dies, the nuke is disabled.
