### PR TITLE
Floodlight nerf

### DIFF
--- a/code/game/machinery/floodlamp.dm
+++ b/code/game/machinery/floodlamp.dm
@@ -8,6 +8,7 @@
 	icon_state = "flood000"
 
 	density = 1
+	can_be_unanchored = 1
 
 	var/list/flashlights = list();
 	var/opened = 0
@@ -36,6 +37,9 @@ obj/machinery/flood_lamp/proc/update_brightness()
 		SetLuminosity(0)
 
 obj/machinery/flood_lamp/attack_hand(mob/living/carbon/user)
+	if(!anchored)
+		user << "<span class='warning'>You need to wrench this in place before you can turn it on!</span>"
+		return
 	if(opened && cell && istype(user))
 		cell.loc = get_turf(src)
 		user.put_in_active_hand(cell)
@@ -74,6 +78,10 @@ obj/machinery/flood_lamp/attackby(obj/item/weapon/W, mob/user, params)
 			playsound(loc, 'sound/items/Wirecutter.ogg', 50, 1, -1)
 			update_all()
 			return;
+	if(istype(W, /obj/item/weapon/wrench))
+		if(!istype(loc, /turf/simulated/floor))
+			user << "<span class='warning'>A floor must be present to secure the floodlamp!</span>"
+			return
 	update_appearance()
 
 obj/machinery/flood_lamp/proc/toggle_light()

--- a/code/game/machinery/floodlamp.dm
+++ b/code/game/machinery/floodlamp.dm
@@ -82,6 +82,12 @@ obj/machinery/flood_lamp/attackby(obj/item/weapon/W, mob/user, params)
 		if(!istype(loc, /turf/simulated/floor))
 			user << "<span class='warning'>A floor must be present to secure the floodlamp!</span>"
 			return
+		if(anchored && on)
+			user << "<span class='warning'>You can't do this while the light is on!</span>"
+			return
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		user << "<span class='notice'>You [anchored ? "un" : ""]secure the floodlamp.</span>"
+		anchored = !anchored
 	update_appearance()
 
 obj/machinery/flood_lamp/proc/toggle_light()
@@ -101,7 +107,6 @@ obj/machinery/flood_lamp/assembled
 		flashlights += new/obj/item/device/flashlight(src)
 		flashlights += new/obj/item/device/flashlight(src)
 		..()
-
 
 /obj/item/weapon/paper/flood_lamp
 	name = "paper- 'Floodlamp Operation for Dummies'"

--- a/html/changelogs/MacHac-FloodlampNerf.yml
+++ b/html/changelogs/MacHac-FloodlampNerf.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: MacHac
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "During routine checks of the Space Station 13 facility, a centcom investigator discovered that floodlamps could be turned on without being anchored to the ground.  This was, of course, a flagrant violation of NT regulations, and all floodlamp models have been modified to fix this issue."


### PR DESCRIPTION
Requested by Adam.
### Intent of Pull Request
- Flood lamps can no longer be both moveable and on at the same time.  They can be secured with a wrench.

The days of pulling a floodlamp behind you through maint and farming shadowling tears are over.
