### PR TITLE
Ports /tg/ slime processor picking up nearby dead slimes

### DIFF
--- a/code/modules/food&drinks/kitchen machinery/processor.dm
+++ b/code/modules/food&drinks/kitchen machinery/processor.dm
@@ -29,6 +29,23 @@
 	for(var/obj/item/weapon/stock_parts/manipulator/M in component_parts)
 		rating_speed = M.rating
 
+/obj/machinery/processor/process()
+	..()
+	var/mob/living/simple_animal/slime/picked_slime
+	for(var/mob/living/simple_animal/slime/slime in orange(1,src))
+		if(istype(slime, /mob/living/simple_animal/slime))
+			if(slime.stat)
+				picked_slime = slime
+				break
+	if(!picked_slime)
+		return
+	var/datum/food_processor_process/P = select_recipe(picked_slime)
+	if (!P)
+		return
+
+	src.visible_message("[picked_slime] is sucked into [src].")
+	picked_slime.loc = src
+		
 /datum/food_processor_process
 	var/input
 	var/output

--- a/html/changelogs/xthedark-slime_processor_thing.yml
+++ b/html/changelogs/xthedark-slime_processor_thing.yml
@@ -1,0 +1,6 @@
+author: X-TheDark
+
+delete-after: True
+
+changes: 
+  - rscadd: "(Port from /tg/) Xenobiology slime processor now scoops up nearby dead slimes automatically."


### PR DESCRIPTION
Revisit of #892 
### Intent of your Pull Request

Reimplementation of /tg/ Slime Processor scooping up slimes thing.
Not linking because original credit is in the linked issue.

Changes:
- Uses orange instead of range to get the slimes. As range also processes the center (and it's contents, which would be the scooped up slimes), as per http://www.byond.com/docs/ref/info.html#/proc/range
