### PR TITLE
Pickpocket gloves (and a whole baggage of reworks)

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -44,6 +44,7 @@
 #define slot_s_store		17
 #define slot_in_backpack	18
 #define slot_legcuffed		19
+#define slot_in_belt		20
 
 //Cant seem to find a mob bitflags area other than the powers one
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -445,6 +445,12 @@ var/list/uplink_items = list()
 	item = /obj/item/clothing/under/chameleon
 	cost = 2
 
+/datum/uplink_item/stealthy_tools/chameleon_pickgloves
+	name = "Chameleon Pickpocketing Gloves"
+	desc = "A pair of gloves that make pickpocketing silent, speeds up stripping/planting actions (33%) and allows extra pickpocketing options. Cam camouflage as other types of gloves. Leaves very specific fibers that make it easy to tell these were used if found by detective."
+	item = /obj/item/clothing/gloves/pickpocket/chameleon
+	cost = 4
+
 /datum/uplink_item/stealthy_tools/chameleon_stamp
 	name = "Chameleon Stamp"
 	desc = "A stamp that can be activated to imitate an official Nanotrasen Stamp. The disguised stamp will work exactly like the real stamp and will allow you to forge false documents to gain access or equipment; \

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -447,7 +447,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/stealthy_tools/chameleon_pickgloves
 	name = "Chameleon Pickpocketing Gloves"
-	desc = "A pair of gloves that make pickpocketing silent, speeds up stripping/planting actions (33%) and allows extra pickpocketing options. Cam camouflage as other types of gloves. Leaves very specific fibers that make it easy to tell these were used if found by detective."
+	desc = "A pair of gloves that make pickpocketing silent, speeds up stripping/planting actions (33%) and allows extra pickpocketing options. Can camouflage as other types of gloves. Leaves very specific fibers that make it easy to tell these were used if found by detective."
 	item = /obj/item/clothing/gloves/pickpocket/chameleon
 	cost = 4
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -24,6 +24,7 @@
 	var/allow_quick_gather	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile, 2 = pick all of a type
 	var/preposition = "in" // You put things 'in' a bag, but trays need 'on'.
+	var/strip_time = 30 //Time it takes to directly strip/put-things-into the container from from the strip menu
 
 
 /obj/item/weapon/storage/MouseDrop(atom/over_object)
@@ -231,14 +232,14 @@
 
 //This proc return 1 if the item can be picked up and 0 if it can't.
 //Set the stop_messages to stop it from printing messages
-/obj/item/weapon/storage/proc/can_be_inserted(obj/item/W, stop_messages = 0, mob/user)
+/obj/item/weapon/storage/proc/can_be_inserted(obj/item/W, stop_messages = 0, mob/user = usr)
 	if(!istype(W) || (W.flags & ABSTRACT)) return //Not an item
 
 	if(loc == W)
 		return 0 //Means the item is already in the storage item
 	if(contents.len >= storage_slots)
 		if(!stop_messages)
-			usr << "<span class='warning'>[src] is full, make some space!</span>"
+			user << "<span class='warning'>[src] is full!</span>"
 		return 0 //Storage item is full
 
 	if(src in W.contents)
@@ -252,13 +253,13 @@
 				break
 		if(!ok)
 			if(!stop_messages)
-				usr << "<span class='warning'>[src] cannot hold [W]!</span>"
+				user << "<span class='warning'>[src] cannot hold [W]!</span>"
 			return 0
 
 	for(var/A in cant_hold) //Check for specific items which this container can't hold.
 		if(istype(W, A))
 			if(!stop_messages)
-				usr << "<span class='warning'>[src] cannot hold [W]!</span>"
+				user << "<span class='warning'>[src] cannot hold [W]!</span>"
 			return 0
 
 	// Check for forbidden items inside the object, if it is a container itself
@@ -268,12 +269,12 @@
 			for(var/A in cant_hold) //Check for specific items which this container can't hold.
 				if(istype(O, A))
 					if(!stop_messages)
-						usr << "<span class='warning'>[src] cannot hold [O] (even inside [W])!</span>"
+						user << "<span class='warning'>[src] cannot hold [O] (even inside [W])!</span>"
 					return 0
 
 	if(W.w_class > max_w_class)
 		if(!stop_messages)
-			usr << "<span class='warning'>[W] is too big for [src]!</span>"
+			user << "<span class='warning'>[W] is too big for [src]!</span>"
 		return 0
 
 	var/sum_w_class = W.w_class
@@ -282,17 +283,17 @@
 
 	if(sum_w_class > max_combined_w_class)
 		if(!stop_messages)
-			usr << "<span class='warning'>[W] won't fit in [src], make some space!</span>"
+			user << "<span class='warning'>[W] won't fit in [src]!</span>"
 		return 0
 
 	if(W.w_class >= w_class && (istype(W, /obj/item/weapon/storage)))
 		if(!istype(src, /obj/item/weapon/storage/backpack/holding) && !istype(src, /obj/item/weapon/storage/belt/fannypack/holding))	//bohs should be able to hold backpacks again. The override for putting a boh in a boh is in backpack.dm.
 			if(!stop_messages)
-				usr << "<span class='warning'>[src] cannot hold [W] as it's a storage item of the same size!</span>"
+				user << "<span class='warning'>[src] cannot hold [W] as it's a storage item of the same size!</span>"
 			return 0 //To prevent the stacking of same sized storage items.
 
 	if(W.flags & NODROP) //SHOULD be handled in unEquip, but better safe than sorry.
-		usr << "<span class='warning'>\the [W] is stuck to your hand, you can't put it in \the [src]!</span>"
+		user << "<span class='warning'>\the [W] is stuck to your hand, you can't put it in \the [src]!</span>"
 		return 0
 
 	return 1
@@ -360,7 +361,6 @@
 	update_icon()
 	W.mouse_opacity = initial(W.mouse_opacity)
 	return 1
-
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/weapon/storage/attackby(obj/item/W, mob/user, params)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -114,29 +114,30 @@ BLIND     // can't see anything
 	return message
 
 //Proc that moves gas/breath masks out of the way, disabling them and allowing pill/food consumption
-/obj/item/clothing/mask/proc/adjustmask(mob/user)
+/obj/item/clothing/mask/proc/adjustmask(mob/user, silent = 0)
 	if(!ignore_maskadjust)
 		if(user.incapacitated())
 			return
-		if(src.mask_adjusted == 1)
+		mask_adjusted = !mask_adjusted
+		if(!mask_adjusted)
 			src.icon_state = initial(icon_state)
 			gas_transfer_coefficient = initial(gas_transfer_coefficient)
 			permeability_coefficient = initial(permeability_coefficient)
 			flags |= visor_flags
 			flags_inv |= visor_flags_inv
 			flags_cover = initial(flags_cover)
-			user << "<span class='notice'>You push \the [src] back into place.</span>"
-			src.mask_adjusted = 0
+			if(!silent)
+				user << "<span class='notice'>You push \the [src] back into place.</span>"
 			slot_flags = initial(slot_flags)
 		else
 			src.icon_state += "_up"
-			user << "<span class='notice'>You push \the [src] out of the way.</span>"
+			if(!silent)
+				user << "<span class='notice'>You push \the [src] out of the way.</span>"
 			gas_transfer_coefficient = null
 			permeability_coefficient = null
 			flags &= ~visor_flags
 			flags_inv &= ~visor_flags_inv
 			flags_cover &= 0
-			src.mask_adjusted = 1
 			if(adjusted_flags)
 				slot_flags = adjusted_flags
 		usr.update_inv_wear_mask()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -8,7 +8,7 @@
 	var/visor_flags_inv = 0		// same as visor_flags, but for flags_inv
 	lefthand_file = 'icons/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing_righthand.dmi'
-	var/alt_desc = null
+	var/fiber_text = null
 	var/toggle_message = null
 	var/alt_toggle_message = null
 	var/active_sound = null
@@ -20,6 +20,11 @@
 	var/canbetorn //can this particular item be torn down to be used for cloth?
 	var/tearhealth = 100
 	var/scan_reagents = 0 //this variable decides if the wearer can see reagents
+
+/obj/item/clothing/New()
+	if(!fiber_text) //used in add_fibers() to set fibers to the name (so we can have different name/set of fibers left)
+		fiber_text = name
+	..()
 
 //Ears: currently only used for headsets and earmuffs
 /obj/item/clothing/ears

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -19,7 +19,7 @@
 	item_state = "ygloves"
 	siemens_coefficient = 1			//Set to a default of 1, gets overridden in New()
 	permeability_coefficient = 0.05
-	item_color="yellow"
+	item_color = "yellow"
 	burn_state = -1 //Won't burn in fires
 
 /obj/item/clothing/gloves/color/fyellow/New()
@@ -30,7 +30,7 @@
 	name = "black gloves"
 	icon_state = "black"
 	item_state = "bgloves"
-	item_color="brown"
+	item_color = "brown"
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
@@ -57,7 +57,7 @@
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "orange"
 	item_state = "orangegloves"
-	item_color="orange"
+	item_color = "orange"
 
 /obj/item/clothing/gloves/color/red
 	name = "red gloves"
@@ -88,28 +88,28 @@
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "blue"
 	item_state = "bluegloves"
-	item_color="blue"
+	item_color = "blue"
 
 /obj/item/clothing/gloves/color/purple
 	name = "purple gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "purple"
 	item_state = "purplegloves"
-	item_color="purple"
+	item_color = "purple"
 
 /obj/item/clothing/gloves/color/green
 	name = "green gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "green"
 	item_state = "greengloves"
-	item_color="green"
+	item_color = "green"
 
 /obj/item/clothing/gloves/color/grey
 	name = "grey gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "gray"
 	item_state = "graygloves"
-	item_color="grey"
+	item_color = "grey"
 
 /obj/item/clothing/gloves/color/grey/rd
 	item_color = "director"			//Exists for washing machines. Is not different from gray gloves in any way.
@@ -122,14 +122,14 @@
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "lightbrown"
 	item_state = "lightbrowngloves"
-	item_color="light brown"
+	item_color = "light brown"
 
 /obj/item/clothing/gloves/color/brown
 	name = "brown gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "brown"
 	item_state = "browngloves"
-	item_color="brown"
+	item_color = "brown"
 
 /obj/item/clothing/gloves/color/brown/cargo
 	item_color = "cargo"					//Exists for washing machines. Is not different from brown gloves in any way.
@@ -155,7 +155,7 @@
 	item_state = "lgloves"
 	siemens_coefficient = 0.30
 	permeability_coefficient = 0.01
-	item_color="white"
+	item_color = "white"
 	transfer_prints = TRUE
 	burn_state = -1 //Won't burn in fires
 
@@ -172,7 +172,7 @@
 	desc = "These look pretty fancy."
 	icon_state = "white"
 	item_state = "wgloves"
-	item_color="mime"
+	item_color = "mime"
 
 /obj/item/clothing/gloves/color/white/redcoat
 	item_color = "redcoat"		//Exists for washing machines. Is not different from white gloves in any way.

--- a/code/modules/clothing/gloves/pickpocket.dm
+++ b/code/modules/clothing/gloves/pickpocket.dm
@@ -1,0 +1,71 @@
+#define SEE_POCKETS		1
+#define SEE_BACKPACK	2
+#define SEE_BELT		4
+
+/obj/item/clothing/gloves/pickpocket
+	desc = "Gloves for those sticky fingers of yours."
+	name = "pickpocket gloves"
+	var/strip_coeff = 0.33 //Stripping is 33% faster
+	var/silent_strip = 1 //no messages while stripping
+	var/silent_internals = 1 //silent internals toggling
+	var/strip_visibility_flags = 0 //what can we see when we wear these
+	var/put_in_hand = 1 //Put whatever we are stealing in-hand?
+
+/obj/item/clothing/gloves/pickpocket/chameleon
+	name = "chameleon pickpocket gloves"
+	desc = "Latest in Syndicate technology. Can reform it's thread color to any color that's used by Nanotrasen."
+	fiber_text = "shiny black gloves"
+	icon_state = "black"
+	item_state = "bgloves"
+	item_color = "brown"
+	strip_visibility_flags = SEE_POCKETS | SEE_BACKPACK | SEE_BELT
+
+	cold_protection = HANDS
+	heat_protection = HANDS
+
+	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
+	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
+
+	burn_state = -1 //Won't burn in fires
+
+	var/list/clothing_choices = list(/obj/item/clothing/gloves/color/yellow,
+			/obj/item/clothing/gloves/color/black,
+			/obj/item/clothing/gloves/color/orange,
+			/obj/item/clothing/gloves/color/red,
+			/obj/item/clothing/gloves/color/rainbow,
+			/obj/item/clothing/gloves/color/blue,
+			/obj/item/clothing/gloves/color/purple,
+			/obj/item/clothing/gloves/color/green,
+			/obj/item/clothing/gloves/color/grey,
+			/obj/item/clothing/gloves/color/light_brown,
+			/obj/item/clothing/gloves/botanic_leather,
+			/obj/item/clothing/gloves/color/latex,
+			/obj/item/clothing/gloves/color/white
+			)
+
+/obj/item/clothing/gloves/pickpocket/chameleon/attack_self(mob/user)
+	var/list/glove_nametypes = list()
+	var/obj/item/clothing/gloves/color/picked
+
+	for(var/CC in clothing_choices)
+		var/obj/item/clothing/gloves/color/GN = CC
+		var/glove_name = initial(GN.name)
+		if(glove_name)
+			glove_nametypes[glove_name] = GN
+
+	var/picked_glove_name
+	picked_glove_name = input(user, "Change gloves to", "Chameleon gloves") as null|anything in glove_nametypes
+
+	if(!picked_glove_name)
+		return
+
+	picked = glove_nametypes[picked_glove_name]
+
+	if(!picked || user.stat)
+		return
+
+	src.name = initial(picked.name)
+	src.desc = initial(picked.desc)
+	src.icon_state = initial(picked.icon_state)
+	src.item_state = initial(picked.item_state)
+	src.item_color = initial(picked.item_color)

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -4,6 +4,7 @@
 /obj/item/clothing/head/helmet/space/hardsuit
 	name = "hardsuit helmet"
 	desc = "A special helmet designed for work in a hazardous, low-pressure environment. Has radiation shielding."
+	var/alt_desc = null
 	icon_state = "hardsuit0-engineering"
 	item_state = "eng_helm"
 	armor = list(melee = 10, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
@@ -42,6 +43,7 @@
 /obj/item/clothing/suit/space/hardsuit
 	name = "hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has radiation shielding."
+	var/alt_desc = null
 	icon_state = "hardsuit-engineering"
 	item_state = "eng_hardsuit"
 	slowdown = 2

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -14,38 +14,47 @@
 	if(!suit_fibers) suit_fibers = list()
 	var/fibertext
 	var/item_multiplier = istype(src,/obj/item)?1.2:1
+
+	var/obj/item/clothing/C // for typecasting
+
 	if(M.wear_suit)
-		fibertext = "Material from \a [M.wear_suit]."
+		C = M.wear_suit
+		fibertext = "Material from \a [C.fiber_text]."
 		if(prob(10*item_multiplier) && !(fibertext in suit_fibers))
 			//world.log << "Added fibertext: [fibertext]"
 			suit_fibers += fibertext
 		if(!(M.wear_suit.body_parts_covered & CHEST))
 			if(M.w_uniform)
-				fibertext = "Fibers from \a [M.w_uniform]."
+				C = M.w_uniform
+				fibertext = "Fibers from \a [C.fiber_text]."
 				if(prob(12*item_multiplier) && !(fibertext in suit_fibers)) //Wearing a suit means less of the uniform exposed.
 					//world.log << "Added fibertext: [fibertext]"
 					suit_fibers += fibertext
 		if(!(M.wear_suit.body_parts_covered & HANDS))
 			if(M.gloves)
-				fibertext = "Material from a pair of [M.gloves.name]."
+				C = M.gloves
+				fibertext = "Material from a pair of [C.fiber_text]."
 				if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
 					//world.log << "Added fibertext: [fibertext]"
 					suit_fibers += fibertext
 	else if(M.w_uniform)
-		fibertext = "Fibers from \a [M.w_uniform]."
+		C = M.w_uniform
+		fibertext = "Fibers from \a [C.fiber_text]."
 		if(prob(15*item_multiplier) && !(fibertext in suit_fibers))
 			// "Added fibertext: [fibertext]"
 			suit_fibers += fibertext
 		if(M.gloves)
-			fibertext = "Material from a pair of [M.gloves.name]."
+			C = M.gloves
+			fibertext = "Material from a pair of [C.fiber_text]."
 			if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
 				//world.log << "Added fibertext: [fibertext]"
-				suit_fibers += "Material from a pair of [M.gloves.name]."
+				suit_fibers += "Material from a pair of [C.fiber_text]."
 	else if(M.gloves)
-		fibertext = "Material from a pair of [M.gloves.name]."
+		C = M.gloves
+		fibertext = "Material from a pair of [C.fiber_text]."
 		if(prob(20*item_multiplier) && !(fibertext in suit_fibers))
 			//world.log << "Added fibertext: [fibertext]"
-			suit_fibers += "Material from a pair of [M.gloves.name]."
+			suit_fibers += "Material from a pair of [C.fiber_text]."
 
 /atom/proc/add_hiddenprint(mob/living/M)
 	if(isnull(M)) return

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -313,30 +313,48 @@
 	user << browse(dat, "window=mob\ref[src];size=325x500")
 	onclose(user, "mob\ref[src]")
 
-/mob/living/carbon/Topic(href, href_list)
-	..()
+/mob/living/carbon/Topic(href, href_list, strip_coeff = 0, silent_strip = 0, silent_internals = 0, put_in_hand = 0)
+	..(href, href_list, strip_coeff, silent_strip, put_in_hand)
 	//strip panel
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["internal"])
 			var/slot = text2num(href_list["internal"])
-			var/obj/item/ITEM = get_item_by_slot(slot)
-			if(ITEM && istype(ITEM, /obj/item/weapon/tank) && wear_mask && (wear_mask.flags & MASKINTERNALS))
-				visible_message("<span class='danger'>[usr] tries to [internal ? "close" : "open"] the valve on [src]'s [ITEM].</span>", \
-								"<span class='userdanger'>[usr] tries to [internal ? "close" : "open"] the valve on [src]'s [ITEM].</span>")
-				if(do_mob(usr, src, POCKET_STRIP_DELAY))
-					if(internal)
-						internal = null
-						if(internals)
-							internals.icon_state = "internal0"
-					else if(ITEM && istype(ITEM, /obj/item/weapon/tank) && wear_mask && (wear_mask.flags & MASKINTERNALS))
-						internal = ITEM
-						if(internals)
-							internals.icon_state = "internal1"
-
-					visible_message("<span class='danger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>", \
-									"<span class='userdanger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>")
-
-
+			switch(slot)
+				if(slot_wear_mask)
+					var/obj/item/clothing/mask/breath_mask = wear_mask
+					if(!breath_mask)
+						return
+					else
+						if(!silent_internals)
+							visible_message("<span class='danger'>[usr] slides [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face.</span>", \
+											"<span class='userdanger'>[usr] slides [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face.</span>")
+						else
+							usr << "<span class='notice'>You silenty slide [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face...but how?</span>"
+						breath_mask.adjustmask(usr)
+						if(usr.machine == src && in_range(src, usr))
+							show_inv(usr)
+				else
+					var/obj/item/ITEM = get_item_by_slot(slot)
+					if(ITEM && istype(ITEM, /obj/item/weapon/tank) && wear_mask && (wear_mask.flags & MASKINTERNALS))
+						if(!silent_internals)
+							visible_message("<span class='danger'>[usr] tries to [internal ? "close" : "open"] the valve on [src]'s [ITEM].</span>", \
+											"<span class='userdanger'>[usr] tries to [internal ? "close" : "open"] the valve on [src]'s [ITEM].</span>")
+						else
+							usr << "<span class='notice'>You silenty try to [internal ? "close" : "open"] the valve on [src]'s [ITEM].</span>"
+						if(do_mob(usr, src, POCKET_STRIP_DELAY*(1-strip_coeff)))
+							if(internal)
+								internal = null
+								if(internals)
+									internals.icon_state = "internal0"
+							else if(ITEM && istype(ITEM, /obj/item/weapon/tank) && wear_mask && (wear_mask.flags & MASKINTERNALS))
+								internal = ITEM
+								if(internals)
+									internals.icon_state = "internal1"
+							if(!silent_internals)
+								visible_message("<span class='danger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>", \
+												"<span class='userdanger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>")
+							else
+								usr << "<span class='notice'>You silenty [internal ? "open" : "close"] the valve on [src]'s [ITEM].</span>"
 
 /mob/living/carbon/getTrail()
 	if(getBruteLoss() < 300)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -322,17 +322,17 @@
 			switch(slot)
 				if(slot_wear_mask)
 					var/obj/item/clothing/mask/breath_mask = wear_mask
-					if(!breath_mask)
+					if(!breath_mask || breath_mask.ignore_maskadjust)
 						return
 					else
 						if(!silent_internals)
 							visible_message("<span class='danger'>[usr] slides [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face.</span>", \
 											"<span class='userdanger'>[usr] slides [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face.</span>")
+							if(!do_mob(usr, src, 20)) //2 seconds to react
+								usr << "<span class='warning'>You failed to slide the mask [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face.</span>"
 						else
-							usr << "<span class='notice'>You silenty slide [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face...but how?</span>"
-						breath_mask.adjustmask(usr)
-						if(usr.machine == src && in_range(src, usr))
-							show_inv(usr)
+							usr << "<span class='notice'>You silently slide [breath_mask] [breath_mask.mask_adjusted ? "on" : "off"] [src]'s face...but how?</span>"
+						breath_mask.adjustmask(usr, silent_internals)
 				else
 					var/obj/item/ITEM = get_item_by_slot(slot)
 					if(ITEM && istype(ITEM, /obj/item/weapon/tank) && wear_mask && (wear_mask.flags & MASKINTERNALS))
@@ -355,6 +355,8 @@
 												"<span class='userdanger'>[usr] [internal ? "opens" : "closes"] the valve on [src]'s [ITEM].</span>")
 							else
 								usr << "<span class='notice'>You silenty [internal ? "open" : "close"] the valve on [src]'s [ITEM].</span>"
+			if(usr.machine == src && in_range(src, usr))
+				show_inv(usr)
 
 /mob/living/carbon/getTrail()
 	if(getBruteLoss() < 300)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -219,7 +219,8 @@
 		dat += "<tr><td><B>Mask:</B></td><td><A href='?src=\ref[src];item=[slot_wear_mask]'>[(wear_mask && !(wear_mask.flags&ABSTRACT)) ? wear_mask : "<font color=grey>Empty</font>"]</A>"
 		if(has_breathable_mask)
 			var/obj/item/clothing/mask/breath_mask = wear_mask
-			dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_wear_mask]'>[breath_mask.mask_adjusted ? "Slide On" : "Slide Off"]</A></td></tr>"
+			if(!breath_mask.ignore_maskadjust)
+				dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_wear_mask]'>[breath_mask.mask_adjusted ? "Slide On" : "Slide Off"]</A></td></tr>"
 
 	if(slot_glasses in obscured)
 		dat += "<tr><td><font color=grey><B>Eyes:</B></font></td><td><font color=grey>Obscured</font></td></tr>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -182,6 +182,12 @@
 	user.set_machine(src)
 	var/has_breathable_mask = istype(wear_mask, /obj/item/clothing/mask)
 	var/list/obscured = check_obscured_slots()
+	var/obj/item/clothing/gloves/pickpocket/usr_gloves
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.gloves && istype(H.gloves, /obj/item/clothing/gloves/pickpocket))
+			usr_gloves = H.gloves
 
 	var/dat = {"<table>
 	<tr><td><B>Left Hand:</B></td><td><A href='?src=\ref[src];item=[slot_l_hand]'>[(l_hand && !(l_hand.flags&ABSTRACT)) ? l_hand : "<font color=grey>Empty</font>"]</A></td></tr>
@@ -190,16 +196,30 @@
 
 	dat += "<tr><td><B>Back:</B></td><td><A href='?src=\ref[src];item=[slot_back]'>[(back && !(back.flags&ABSTRACT)) ? back : "<font color=grey>Empty</font>"]</A>"
 	if(has_breathable_mask && istype(back, /obj/item/weapon/tank))
-		dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_back]'>[internal ? "Disable Internals" : "Set Internals"]</A>"
+		dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_back]'>[internal ? "Disable Internals" : "Set Internals"]</A></td></tr>"
+	else
+		dat += "</td></tr>"
 
-	dat += "</td></tr><tr><td>&nbsp;</td></tr>"
+	if(usr_gloves && (usr_gloves.strip_visibility_flags & SEE_BACKPACK))
+		if(istype(back, /obj/item/weapon/storage/backpack))
+			var/obj/item/weapon/storage/backpack/pack = back
+			if(pack.contents.len)
+				for(var/obj/C in back.contents)
+					dat += "<tr><td>&nbsp;&#8627;<B></B></td><td><A href='?src=\ref[src];item=[slot_in_backpack];item_ref=\ref[C]'>[C]</A></td></tr>"
+			else
+				dat += "<tr><td>&nbsp;&#8627;<B></B></td><td><A href='?src=\ref[src];item=[slot_in_backpack];item_ref=0'>["<font color=grey>Empty</font>"]</A></td></tr>"
+
+	dat += "<tr><td>&nbsp;</td></tr>"
 
 	dat += "<tr><td><B>Head:</B></td><td><A href='?src=\ref[src];item=[slot_head]'>[(head && !(head.flags&ABSTRACT)) ? head : "<font color=grey>Empty</font>"]</A></td></tr>"
 
 	if(slot_wear_mask in obscured)
 		dat += "<tr><td><font color=grey><B>Mask:</B></font></td><td><font color=grey>Obscured</font></td></tr>"
 	else
-		dat += "<tr><td><B>Mask:</B></td><td><A href='?src=\ref[src];item=[slot_wear_mask]'>[(wear_mask && !(wear_mask.flags&ABSTRACT)) ? wear_mask : "<font color=grey>Empty</font>"]</A></td></tr>"
+		dat += "<tr><td><B>Mask:</B></td><td><A href='?src=\ref[src];item=[slot_wear_mask]'>[(wear_mask && !(wear_mask.flags&ABSTRACT)) ? wear_mask : "<font color=grey>Empty</font>"]</A>"
+		if(has_breathable_mask)
+			var/obj/item/clothing/mask/breath_mask = wear_mask
+			dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_wear_mask]'>[breath_mask.mask_adjusted ? "Slide On" : "Slide Off"]</A></td></tr>"
 
 	if(slot_glasses in obscured)
 		dat += "<tr><td><font color=grey><B>Eyes:</B></font></td><td><font color=grey>Obscured</font></td></tr>"
@@ -246,8 +266,28 @@
 		if(has_breathable_mask && istype(belt, /obj/item/weapon/tank))
 			dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_belt]'>[internal ? "Disable Internals" : "Set Internals"]</A>"
 		dat += "</td></tr>"
-		dat += "<tr><td>&nbsp;&#8627;<B>Pockets:</B></td><td><A href='?src=\ref[src];pockets=left'>[(l_store && !(l_store.flags&ABSTRACT)) ? "Left (Full)" : "<font color=grey>Left (Empty)</font>"]</A>"
-		dat += "&nbsp;<A href='?src=\ref[src];pockets=right'>[(r_store && !(r_store.flags&ABSTRACT)) ? "Right (Full)" : "<font color=grey>Right (Empty)</font>"]</A></td></tr>"
+
+		if(usr_gloves && (usr_gloves.strip_visibility_flags & SEE_BELT))
+			if(istype(belt, /obj/item/weapon/storage/belt))
+				var/obj/item/weapon/storage/belt/src_belt = belt
+				if(src_belt.contents.len)
+					for(var/obj/C in src_belt.contents)
+						dat += "<tr><td>&nbsp;&nbsp;&nbsp;&#8627;<B></B></td><td><A href='?src=\ref[src];item=[slot_in_belt];item_ref=\ref[C]'>[C]</A></td></tr>"
+				else
+					dat += "<tr><td>&nbsp;&nbsp;&nbsp;&#8627;<B></B></td><td><A href='?src=\ref[src];item=[slot_in_belt];item_ref=0'>["<font color=grey>Empty</font>"]</A></td></tr>"
+
+		if(usr_gloves && (usr_gloves.strip_visibility_flags & SEE_POCKETS))
+			dat += "<tr><td>&nbsp;&#8627;<B>Pocket (Left):</B></td><td><A href='?src=\ref[src];pockets=left'>[(l_store && !(l_store.flags&ABSTRACT)) ? l_store : "<font color=grey>Empty</font>"]</A>"
+			if(has_breathable_mask && istype(l_store, /obj/item/weapon/tank))
+				dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_l_store]'>[internal ? "Disable Internals" : "Set Internals"]</A>"
+			dat += "</td></tr>"
+			dat += "<tr><td>&nbsp;&#8627;<B>Pocket (Right):</B></td><td><A href='?src=\ref[src];pockets=right'>[(r_store && !(r_store.flags&ABSTRACT)) ? r_store : "<font color=grey>Empty</font>"]</A>"
+			if(has_breathable_mask && istype(r_store, /obj/item/weapon/tank))
+				dat += "&nbsp;<A href='?src=\ref[src];internal=[slot_r_store]'>[internal ? "Disable Internals" : "Set Internals"]</A>"
+			dat += "</td></tr>"
+		else
+			dat += "<tr><td>&nbsp;&#8627;<B>Pockets:</B></td><td><A href='?src=\ref[src];pockets=left'>[(l_store && !(l_store.flags&ABSTRACT)) ? "Left (Full)" : "<font color=grey>Left (Empty)</font>"]</A>"
+			dat += "&nbsp;<A href='?src=\ref[src];pockets=right'>[(r_store && !(r_store.flags&ABSTRACT)) ? "Right (Full)" : "<font color=grey>Right (Empty)</font>"]</A></td></tr>"
 		dat += "<tr><td>&nbsp;&#8627;<B>ID:</B></td><td><A href='?src=\ref[src];item=[slot_wear_id]'>[(wear_id && !(wear_id.flags&ABSTRACT)) ? wear_id : "<font color=grey>Empty</font>"]</A></td></tr>"
 
 	for (var/obj/item/organ/limb/org in organs)
@@ -310,7 +350,6 @@
 
 /mob/living/carbon/human/Topic(href, href_list)
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
-
 		if(href_list["embedded_object"])
 			var/obj/item/I = locate(href_list["embedded_object"])
 			var/obj/item/organ/limb/L = locate(href_list["embedded_limb"])
@@ -342,11 +381,29 @@
 					src << "<span class='warning'>You feel something tugging on your bandages!</span>"
 			return
 
+		var/strip_coeff = 0
+		var/silent_internals = 0
+		var/silent_strip = 0
+		var/pickpocket_gloves = 0
+		var/put_in_hand = 0
+
+		if(istype(usr, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = usr
+			if(H.gloves && istype(H.gloves, /obj/item/clothing/gloves/pickpocket/))
+				var/obj/item/clothing/gloves/pickpocket/gloves = H.gloves
+				strip_coeff = min(gloves.strip_coeff, 1)
+				silent_internals = gloves.silent_internals
+				silent_strip = gloves.silent_strip
+				pickpocket_gloves = 1
+				put_in_hand = gloves.put_in_hand
+
 		if(href_list["item"])
 			var/slot = text2num(href_list["item"])
+			if((slot == slot_in_backpack) || (slot == slot_in_belt))
+				if(!pickpocket_gloves)
+					return
 			if(slot in check_obscured_slots())
 				usr << "<span class='warning'>You can't reach that! Something is covering it.</span>"
-				return
 
 		if(href_list["pockets"])
 			var/pocket_side = href_list["pockets"]
@@ -365,10 +422,12 @@
 			else
 				return
 
-			if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
+			if(do_mob(usr, src, POCKET_STRIP_DELAY*(1-strip_coeff)/delay_denominator)) //placing an item into the pocket is 4 times faster
 				if(pocket_item)
 					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
 						unEquip(pocket_item)
+						if(put_in_hand)
+							usr.put_in_hands(pocket_item)
 				else
 					if(place_item)
 						usr.unEquip(place_item)
@@ -381,7 +440,7 @@
 				// Display a warning if the user mocks up
 				src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
 
-		..()
+		..(href, href_list, strip_coeff, silent_strip, silent_internals, put_in_hand)
 
 
 ///////HUDs///////

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -145,9 +145,15 @@
 					return 0
 				return 1
 			if(slot_in_backpack)
-				if (back && istype(back, /obj/item/weapon/storage/backpack))
+				if(back && istype(back, /obj/item/weapon/storage/backpack))
 					var/obj/item/weapon/storage/backpack/B = back
-					if(B.contents.len < B.storage_slots && I.w_class <= B.max_w_class)
+					if(B.can_be_inserted(I, 1))
+						return 1
+				return 0
+			if(slot_in_belt)
+				if(belt && istype(belt, /obj/item/weapon/storage/belt))
+					var/obj/item/weapon/storage/belt/B = belt
+					if(B.can_be_inserted(I, 1))
 						return 1
 				return 0
 		return 0 //Unsupported slot
@@ -197,21 +203,17 @@
 
 
 // Return the item currently in the slot ID
-/mob/living/carbon/human/get_item_by_slot(slot_id)
+/mob/living/carbon/human/get_item_by_slot(slot_id, obj/item/what = null)
 	switch(slot_id)
-		if(slot_back)
-			return back
-		if(slot_wear_mask)
-			return wear_mask
-		if(slot_handcuffed)
-			return handcuffed
-		if(slot_legcuffed)
-			return legcuffed
-		if(slot_l_hand)
-			return l_hand
-		if(slot_r_hand)
-			return r_hand
 		if(slot_belt)
+			return belt
+		if(slot_in_belt)
+			if(what)
+				if(belt && istype(belt, /obj/item/weapon/storage/belt))
+					var/obj/item/weapon/storage/belt/item = belt
+					if(what in item.contents)
+						return what
+					return null
 			return belt
 		if(slot_wear_id)
 			return wear_id
@@ -221,8 +223,6 @@
 			return glasses
 		if(slot_gloves)
 			return gloves
-		if(slot_head)
-			return head
 		if(slot_shoes)
 			return shoes
 		if(slot_wear_suit)
@@ -235,7 +235,8 @@
 			return r_store
 		if(slot_s_store)
 			return s_store
-	return null
+		else
+			. = ..() //sets return to what parent returns
 
 
 /mob/living/carbon/human/unEquip(obj/item/I)
@@ -386,6 +387,10 @@
 			if(get_active_hand() == I)
 				unEquip(I)
 			I.loc = back
+		if(slot_in_belt)
+			if(get_active_hand() == I)
+				unEquip(I)
+			I.loc = belt
 		else
 			src << "<span class='danger'>You are trying to equip this item to an unsupported inventory slot. Report this to a coder!</span>"
 			return

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -548,9 +548,15 @@
 				return 0
 			return 1
 		if(slot_in_backpack)
-			if (H.back && istype(H.back, /obj/item/weapon/storage/backpack))
+			if(H.back && istype(H.back, /obj/item/weapon/storage/backpack))
 				var/obj/item/weapon/storage/backpack/B = H.back
-				if(B.contents.len < B.storage_slots && I.w_class <= B.max_w_class)
+				if(B.can_be_inserted(I, 1))
+					return 1
+			return 0
+		if(slot_in_belt)
+			if(H.belt && istype(H.belt, /obj/item/weapon/storage/belt))
+				var/obj/item/weapon/storage/belt/B = H.belt
+				if(B.can_be_inserted(I, 1))
 					return 1
 			return 0
 	return 0 //Unsupported slot

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -1,6 +1,14 @@
-/mob/living/carbon/get_item_by_slot(slot_id)
+/mob/living/carbon/get_item_by_slot(slot_id, obj/item/what = null)
 	switch(slot_id)
 		if(slot_back)
+			return back
+		if(slot_in_backpack)
+			if(what)
+				if(back && istype(back, /obj/item/weapon/storage/backpack))
+					var/obj/item/weapon/storage/backpack/pack = back
+					if(what in pack.contents)
+						return what
+					return null
 			return back
 		if(slot_wear_mask)
 			return wear_mask
@@ -10,12 +18,8 @@
 			return handcuffed
 		if(slot_legcuffed)
 			return legcuffed
-		if(slot_l_hand)
-			return l_hand
-		if(slot_r_hand)
-			return r_hand
-	return null
-
+		else
+			. = ..()
 
 /mob/living/carbon/unEquip(obj/item/I) //THIS PROC DID NOT CALL ..() AND THAT COST ME AN ENTIRE DAY OF DEBUGGING.
 	. = ..() //Sets the default return value to what the parent returns.

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -184,7 +184,7 @@ var/next_mob_id = 0
 /mob/proc/Life()
 	return
 
-/mob/proc/get_item_by_slot(slot_id)
+/mob/proc/get_item_by_slot(slot_id, obj/item/what = null)
 	switch(slot_id)
 		if(slot_l_hand)
 			return l_hand
@@ -624,7 +624,7 @@ var/list/slot_equipment_priority = list( \
 	reset_view(null)
 	unset_machine()
 
-/mob/Topic(href, href_list)
+/mob/Topic(href, href_list, strip_coeff = 0, silent_strip = 0, put_in_hand = 0)
 	if(href_list["mach_close"])
 		var/t1 = text("window=[href_list["mach_close"]]")
 		unset_machine()
@@ -636,13 +636,18 @@ var/list/slot_equipment_priority = list( \
 
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["item"])
+			var/obj/item/what
 			var/slot = text2num(href_list["item"])
-			var/obj/item/what = get_item_by_slot(slot)
+			if(href_list["item_ref"])
+				if(href_list["item_ref"] != "0" && !usr.get_active_hand())
+					what = locate(href_list["item_ref"])
+			else
+				what = get_item_by_slot(slot)
 
 			if(what)
-				usr.stripPanelUnequip(what,src,slot)
+				usr.stripPanelUnequip(what, src, slot, strip_coeff, silent_strip, put_in_hand)
 			else
-				usr.stripPanelEquip(what,src,slot)
+				usr.stripPanelEquip(what, src, slot, strip_coeff, silent_strip)
 
 	if(usr.machine == src)
 		if(Adjacent(usr))

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -944,6 +944,7 @@
 #include "code\modules\clothing\gloves\boxing.dm"
 #include "code\modules\clothing\gloves\color.dm"
 #include "code\modules\clothing\gloves\miscellaneous.dm"
+#include "code\modules\clothing\gloves\pickpocket.dm"
 #include "code\modules\clothing\head\collectable.dm"
 #include "code\modules\clothing\head\hardhat.dm"
 #include "code\modules\clothing\head\helmet.dm"


### PR DESCRIPTION
Refer to issue #886.

**TL:DR Pickpocket Gloves + alot of code to support that : faster stripping, can plant/strip from backpack/belt. Also can see pockets/toggle internals from pocket slots. Masks can now be adjusted on person, regardless of these gloves. Instant, but visible without the special gloves.**

**Probably needs some testing too, but I've tested it with probably most common human interactions during implementation/testing. Other mob stripping will probably not work as well.**
### Gloves themselves

Pickpocket gloves, as Adam envisioned, with an additional touch from me by making the Chameleon.

Features of gloves themselves:
- New subtype of gloves (/gloves/pickpocket) that have 3 visibility flags which control what extra slots you see or don't see.;
- **Strip coefficient** that controls how much faster stripping/planting happens (almost all of it). Ranges up to 1 (0 = 0% faster, 1 = 100% faster, aka instant, supports negative values);
- The only exception to the above is stripping/planting container items directly - stripping from container is full-container time (explained below), planting into container (backpack/belt, btw, no planting insider containers inside containers) respects strip coefficient (so it's faster to plant);
- Containers now have a **strip_time** var defined - tells you how long it takes to STRIP from this container, when it's on the person (only applicable to backpacks/belts at the moment, but defined for all storage objects). PLANTING is multiplied by strip coefficient, making it faster (barring negative coefficient value shenanigans);
- Stipping/Planting is silent to the target;
- All movement rules apply normally - they move, you lose;
- If pockets contain internal tanks, you can switch them on/off now;
- Stripping puts the item into your hand. For stripping items, if they cannot be placed into your ACTIVE HAND, they get dropped UNDER YOUR MOB (instead of under your target)
- You can only strip one item from container (backpack/belt on target) at a time, due to how stripping/planting is implemented (read in the instruction book below);
- Can silently toggle internals (including Pocket slots);
### The enclosed instruction book:
- Stripping normal slots works the same way;
- To PLANT an item into a container, hold item in your hand and CLICK ON ONE OF THE CONTENTS OF THE BACKPACK (or the word Empty, if it's empty);
- To STRIP an item from a container, have YOUR HAND EMPTY and click on the item in the container;
- Available for 4 TC from your nearest Syndicate Uplink;
## Groundwork changes (reworks)
- obj/clothing variable **alt_desc** changed to **fiber_text** (as it was previously used **IN 2 ITEMS OUT OF ALL THE CLOTHES EXISTING**, namely syndie hardsuit/helmet. Alt_desc defined for those two separately);
- As per above, you now leave **fiber_text** fibertext on anything you touch, this allows different item names and fibers. By default, **fiber_text is set to name of item (in New())**;
- Detective scanner, obviously, now uses fiber_text;
- **New href var** used in show_inv() for humans - **item_ref**, which saves the reference of an item in the container OR 0, if it's empty;
- New slot - **slot_in_belt** : refers to item in, well, belt;
- Various mob/species inventory procs (can_equip/get_item_by_slot) support slot_in_belt, as well as call parent functions and process only their own slots. Additionally, get_item_by_slot now has a **new optional parameter of type /obj/item**, which, if defined, checks that the item is inside backpack/belt (depending on the slot specified). If the optional parameter is not set, it returns the back/belt slots.
- stripPanelEquip/stripPanelUnequip reworked to be capable of working with items inside backpacks/belts.
- Probably some more things I cannot remember...

Oh, right, also, new feature - you can now slide masks off/on someone. It takes 2 seconds to do and is instant with THE GLOVES. People around are alerted when someone does this to you, if you do it without them (similar to taking something off someone - big shiny red message).
# New Inventory Screen

![new_inventory](https://cloud.githubusercontent.com/assets/2188139/14698201/069e854c-0795-11e6-9de2-681138358aee.png)

:cl: X-TheDark
rscadd: Syndicate agents can now purchase Pickpocket Gloves from Stealthy Tools section for 4 TC. These gloves can disguise themselves as other gloves by holding them in-hand and clicking on them.
rscadd: Pickpocket gloves make stripping/planting_on_person 33% faster than normal. You can also remove/place items directly into belts/backpacks worn by the target. These gloves also allow you to see what's inside the targets pockets. In addition, stripping/planting items is SILENT with these (target only gets the message of the attempt if you fail). As a bonus, the item you strip from the target is placed in your hand, instead of the targets feet.
rscadd: To place an item into belt/backpack, hold whatever you want to place in your hand and click on any item in the backpack/belt contents thing. To remove an item, have your hand empty and click on any contents of the backpack/belt.
rscadd: Oh, also, toggling internals on the target is SILENT with these gloves and you can also toggle internals if the target has a emergency tank in one of the pockets.
rscadd: You can now adjust the mask on the target (Slide it in place/off of face), it takes 2 seconds. With pickpocket gloves, it's instant.
/:cl:
