### PR TITLE
Massively buffs powersink

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -12,9 +12,9 @@
 	throw_range = 2
 	materials = list(MAT_METAL=750)
 	origin_tech = "powerstorage=3;syndicate=5"
-	var/drain_rate = 3000000		// amount of power to drain per tick
+	var/drain_rate = 8000000		// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 3e8		// maximum power that can be drained before exploding
+	var/max_power = 4e8		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = 0 // stop spam, only warn the admins once that we are about to boom
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -14,7 +14,7 @@
 	origin_tech = "powerstorage=3;syndicate=5"
 	var/drain_rate = 3000000		// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 6e8		// maximum power that can be drained before exploding
+	var/max_power = 3e8		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = 0 // stop spam, only warn the admins once that we are about to boom
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -12,9 +12,9 @@
 	throw_range = 2
 	materials = list(MAT_METAL=750)
 	origin_tech = "powerstorage=3;syndicate=5"
-	var/drain_rate = 600000		// amount of power to drain per tick
+	var/drain_rate = 3000000		// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power
-	var/max_power = 1e8		// maximum power that can be drained before exploding
+	var/max_power = 6e8		// maximum power that can be drained before exploding
 	var/mode = 0		// 0 = off, 1=clamped (off), 2=operating
 	var/admins_warned = 0 // stop spam, only warn the admins once that we are about to boom
 


### PR DESCRIPTION
Refer to issue #977.

**If you think this is too heavyhanded, feel free to close this, I'll then see about making a powersink that takes into account the power output of whatever singularity the station is using.**
### Intent of your Pull Request

Now that we have the tesla, powersink just plain sucks ass, if the tesla is set up. If it's not, why are you buying this in the first place, I wonder?

Changes:
- Powersink realistically drains ALL produced power @ 8 MW of power per tick (up from 0.6 MW);
- Powersink has a 4 times greater capacity @ 400 000 000 (up from 100 000 000);
### NOW, BEFORE YOU CALL ME OUT OF MY GODDAMN MIND, please read this:
- Once the tesla is setup, if it is wired directly into the grid, it produces 2 MW of energy (which gets to about 3+ MW in the later stages, which might still sometimes invalidate this device);
- Old singularity gives out 2.5 MW when the collectors are full and it is at Stage 2-3 thing (The stable place it stays with PA 0, basically);

Let that sink in for a moment...a 5 minute effort of turning on emitters/shield gens (no modification to layout) and a minor rewiring is getting you GODDAMN 2 MW OF POWER PER TICK, which increases as time goes on to 3+MW.

At this point, a 600kW drain Powersink is not going to cut it at all, hell, it doesn't even drain max output SMES (800k total).

P.S. As a minor thing. This is actually impossible to balance, as, if the singularity (any kind) IS NOT wired to the grid, you get 0.8 MW power, which is going to make this puppy run for a LOOONG time.

Now, if the singularity IS WIRED to the grid, **EVEN WITH THESE RIDICULOUS NUMBERS, you are looking at about a 5 minute powersink life time, out of which, about 1:50 minutes are used to drain the power from station's APCs first (I tested this myself)**. After that you get about 3:34 minutes of blackout.

This can be mitigated by using the old singularity in a risky way - if you keep it around Stage 4 (7x7 size - fills entire containment), it will produce 5 MW (when it's just become S4) up to about 6-7 MW, before you need to turn power off (or not, I won't judge). This reduces the blackout time to about 40 seconds.

:cl: X-TheDark
rscadd: Powersink severely buffed. You can no longer hope to outproduce it's consumption ability. Powersink drains up to 8 MW per second (up from 0.6 MW) and it's capacity is increased from 100 to 400 MW.
rscadd: AI cries, Powernet dies. If you don't have the most basic power set up, you can kiss your power goodbye for the entire round, unless you find this thing.
rscadd: Careful maintenance of high-stage singularity (Stage 4 - the max containment size one) powered production will DRASTICALLY reduce the powersink lifetime, due to ridiculous amounts of energy it produces. Makes sure to plug it into the grid! And makes sure it doesn't grow any more.
/:cl:
