### PR TITLE
Riot shields no longer block ranged projectiles

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -879,7 +879,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/clothing/suit/hooded/carp_costume = 1,
 					/obj/item/clothing/suit/hooded/ian_costume = 1, /obj/item/clothing/under/ronaldmcdonald = 1)
 	contraband = list(/obj/item/clothing/suit/judgerobe = 1,/obj/item/clothing/head/powdered_wig = 1,/obj/item/weapon/gun/magic/wand = 2,/obj/item/clothing/glasses/sunglasses/garb = 2)
-	premium = list(/obj/item/clothing/suit/hgpirate = 2, /obj/item/clothing/head/hgpiratecap = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/riot/roman = 1)
+	premium = list(/obj/item/clothing/suit/hgpirate = 2, /obj/item/clothing/head/hgpiratecap = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/riot/roman/prop = 1)
 	refill_canister = /obj/item/weapon/vending_refill/autodrobe
 
 /obj/machinery/vending/dinnerware

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -21,6 +21,7 @@
 	materials = list(MAT_GLASS=7500, MAT_METAL=1000)
 	origin_tech = "materials=2"
 	attack_verb = list("shoved", "bashed")
+	block_chance = 0
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
 
@@ -34,7 +35,10 @@
 		..()
 
 /obj/item/weapon/shield/riot/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
-	if(attack_type == PROJECTILE_ATTACK)
+	if(attack_type == THROWN_PROJECTILE_ATTACK)
+		final_block_chance += 80 //This is to preserve the original thrown stuff block chance
+		return ..()
+	else if(attack_type == PROJECTILE_ATTACK)
 		return ..()
 	else
 		return 1
@@ -51,6 +55,17 @@
 		return 1
 	else
 		return ..()
+
+/obj/item/weapon/shield/riot/roman/prop
+	name = "mock roman shield"
+	desc = "Made of cheap, lightweight plastic. Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
+	icon_state = "roman_shield"
+	item_state = "roman_shield"
+	force = 3
+	throwforce = 3
+
+/obj/item/weapon/shield/riot/roman/prop/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
+	return 0
 
 /obj/item/weapon/shield/energy
 	name = "energy combat shield"

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -57,10 +57,7 @@
 		return ..()
 
 /obj/item/weapon/shield/riot/roman/prop
-	name = "mock roman shield"
 	desc = "Made of cheap, lightweight plastic. Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
-	icon_state = "roman_shield"
-	item_state = "roman_shield"
 	force = 3
 	throwforce = 3
 

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -36,7 +36,7 @@
 
 /obj/item/weapon/shield/riot/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
-		final_block_chance += 80 //This is to preserve the original thrown stuff block chance
+		final_block_chance += 50 //This is to preserve the original thrown stuff block chance
 		return ..()
 	else if(attack_type == PROJECTILE_ATTACK)
 		return ..()


### PR DESCRIPTION
### Intent of your Pull Request

Riot shields gives complete and total melee immunity in exchange for doing absolutely nothing against ranged projectiles (was 50% chance to block any ranged attack as well as total melee immunity).

You can no longer buy what amounts to a riot shield from AutoDrobe. It's replaced with a mock version that doesn't block anything.

**Should the riot shield have a chance to block some ranged attacks (like, bullets/syringes), but not energy attacks or should it be as this PR suggests, no ranged block whatsoever?**

:cl: X-TheDark
tweak: Riot shields no longer block ranged projectiles.
rscdel: You cannot buy a basically-riot-shield from AutoDrobe anymore. Replaced with a mock version that doesn't block anything.
/:cl:
