### PR TITLE
Warden gets a sechailer in his box.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -74,6 +74,7 @@ Warden
 	default_headset = /obj/item/device/radio/headset/headset_sec/alt
 	default_backpack = /obj/item/weapon/storage/backpack/security
 	default_satchel = /obj/item/weapon/storage/backpack/satchel_sec
+	default_storagebox = /obj/item/weapon/storage/box/security
 
 	access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_maint_tunnels, access_morgue, access_weapons, access_forensics_lockers)
 	minimal_access = list(access_security, access_sec_doors, access_brig, access_armory, access_court, access_weapons) //See /datum/job/warden/get_access()


### PR DESCRIPTION
### Intent of your Pull Request

Warden will start with a sechailer in his box now, instead of a normal breath mask. I'm not sure why this wasn't done before.

So Detective & Lawyers should be the only two jobs of security that don't get sec hailers.

Another thing I wanted to do was give sechailers an action button to adjust them, but there's a hotkey for that.

:cl:Super3222
tweak: Warden now starts with a proper sec hailer.
/:cl:
