### PR TITLE
Nerfs crates health to 300.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -124,7 +124,7 @@
 	var/sparks = "securecratesparks"
 	var/emag = "securecrateemag"
 	locked = 1
-	health = 1000
+	health = 300
 
 /obj/structure/closet/crate/secure/weapon
 	desc = "A secure weapons crate."


### PR DESCRIPTION
### Intent of your Pull Request

Secure crates currently have 1000 HP on their hands.

This will give them 300 health instead, which was recommended by @AdamElTablawy.
Some feedback would be great too. I don't want a giant cargo buff to go silent.

:cl:Super3222
tweak: Secure crates health now is 300 aside from 1000.
/:cl:
