### PR TITLE
Deleting a security record now takes the person off arrest.

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -710,6 +710,9 @@ What a mess.*/
 					if("Delete Record (Security) Execute")
 						investigate_log("[usr.name] ([usr.key]) has deleted the security records for [active1.fields["name"]].", "records")
 						if(active2)
+							active2.fields["criminal"] = "None"
+							for(var/mob/living/carbon/human/H in mob_list)
+								H.sec_hud_set_security_status()
 							data_core.security -= active2
 							qdel(active2)
 
@@ -725,6 +728,9 @@ What a mess.*/
 							qdel(active1)
 
 						if(active2)
+							active2.fields["criminal"] = "None"
+							for(var/mob/living/carbon/human/H in mob_list)
+								H.sec_hud_set_security_status()
 							data_core.security -= active2
 							qdel(active2)
 					else


### PR DESCRIPTION
### Intent of your Pull Request

Previously deleting the security record of someone who was set to arrest (or any other status) would leave them in that status forever.

:cl: 
bugfix: Deleting a security record will now set the person's security status to "none" instead of permanently leaving it at what is was at when the record was deleted.
/:cl:
