### PR TITLE
Gives the rev flash and flashbulb hijacker tech levels

### DIFF
--- a/code/game/gamemodes/revolution/rev_flash.dm
+++ b/code/game/gamemodes/revolution/rev_flash.dm
@@ -5,6 +5,7 @@
 	desc = "You aren't sure what this thing does, but you're almost certain that it can't be good."
 	icon_state = "memorizer"
 	item_state = "nullrod"
+	origin_tech = "syndicate=5;combat=3;magnets=3"
 
 	var/cooldown = 0
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -428,3 +428,4 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implanter1"
 	item_state = "syringe_0"
+	origin_tech = "syndicate=1;bio=4"


### PR DESCRIPTION
### Intent of your Pull Request

Title says it all.
Rev flash gets illegal 5, combat 3, and magnets 3.
Hijacker tool gets illegal 1 and bio 4.

:cl:Super3222
rscadd: Added tech levels to the rev flash and hijacker tool.
/:cl:
