### PR TITLE
Rapid Engineering Devices explode like RCDs with the malf AI module

### DIFF
--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -208,6 +208,8 @@
 
 	for(var/obj/item/RCD in rcd_list)
 		if(!istype(RCD, /obj/item/weapon/rcd/borg)) //Ensures that cyborg RCDs are spared.
+			if(istype(RCD.loc, /obj/item/weapon/rapid_engineering_device)
+				RCD = RCD.loc
 			RCD.audible_message("<span class='danger'><b>[RCD] begins to vibrate and buzz loudly!</b></span>","<span class='danger'><b>[RCD] begins vibrating violently!</b></span>")
 			spawn(40) //4 seconds to get rid of it!
 				if(RCD) //Make sure it still exists (In case of chain-reaction)

--- a/code/game/gamemodes/malfunction/Malf_Modules.dm
+++ b/code/game/gamemodes/malfunction/Malf_Modules.dm
@@ -208,7 +208,7 @@
 
 	for(var/obj/item/RCD in rcd_list)
 		if(!istype(RCD, /obj/item/weapon/rcd/borg)) //Ensures that cyborg RCDs are spared.
-			if(istype(RCD.loc, /obj/item/weapon/rapid_engineering_device)
+			if(istype(RCD.loc, /obj/item/weapon/rapid_engineering_device))
 				RCD = RCD.loc
 			RCD.audible_message("<span class='danger'><b>[RCD] begins to vibrate and buzz loudly!</b></span>","<span class='danger'><b>[RCD] begins vibrating violently!</b></span>")
 			spawn(40) //4 seconds to get rid of it!


### PR DESCRIPTION
Fix for #1016 
### Intent of your Pull Request

Rapid Engineering Devices now explode with the "destroy RCD" malf AI module. Otherwise they would cause all sorts of nullpointers when their internal RCD exploded.
