### PR TITLE
Borgs are NOT exploitable

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -156,11 +156,9 @@
 	updatename()
 	switch(designation)
 		if("Standard")
+			module = new /obj/item/weapon/robot_module/standard(src)
 			var/icontype = input("Select an icon!", "Robot", "Standard") in list("Standard")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/standard(src)
 			hands.icon_state = "standard"
 			switch(icontype)
 				if("Standard")
@@ -171,11 +169,9 @@
 			feedback_inc("cyborg_standard",1)
 
 		if("Service")
+			module = new /obj/item/weapon/robot_module/butler(src)
 			var/icontype = input("Select an icon!", "Robot", "Butler") in list("Waitress", "Bro", "Butler", /*"Kent",*/ "Rich")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/butler(src)
 			hands.icon_state = "service"
 			switch(icontype)
 				if("Waitress")
@@ -196,11 +192,9 @@
 			feedback_inc("cyborg_service",1)
 
 		if("Miner")
+			module = new /obj/item/weapon/robot_module/miner(src)
 			var/icontype = input("Select an icon!", "Robot", "Tread Miner") in list("Tread Miner")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/miner(src)
 			hands.icon_state = "miner"
 			switch(icontype)
 				if("Tread Miner")
@@ -213,11 +207,9 @@
 			feedback_inc("cyborg_miner",1)
 
 		if("Medical")
+			module = new /obj/item/weapon/robot_module/medical(src)
 			var/icontype = input("Select an icon!", "Robot", "Mediborg") in list("Mediborg" , "Medihover", "Smile Screen")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/medical(src)
 			hands.icon_state = "medical"
 			switch(icontype)
 				if("Mediborg")
@@ -236,11 +228,9 @@
 			feedback_inc("cyborg_medical",1)
 
 		if("Security")
+			module = new /obj/item/weapon/robot_module/security(src)
 			var/icontype = input("Select an icon!", "Robot", "Secborg") in list("Secborg", "Treaded Secborg", "Interceptor")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/security(src)
 			hands.icon_state = "security"
 			switch(icontype)
 				if("Secborg")
@@ -260,11 +250,9 @@
 			feedback_inc("cyborg_security",1)
 
 		if("Engineering")
+			module = new /obj/item/weapon/robot_module/engineering(src)
 			var/icontype = input("Select an icon!", "Robot", "Engiborg") in list("Engiborg", "Treaded Engiborg", "Hover Engiborg")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/engineering(src)
 			hands.icon_state = "engineer"
 			switch(icontype)
 				if("Engiborg")
@@ -286,11 +274,9 @@
 			feedback_inc("cyborg_engineering",1)
 
 		if("Janitor")
+			module = new /obj/item/weapon/robot_module/janitor(src)
 			var/icontype = input("Select an icon!", "Robot", "Janiborg") in list("Janiborg", "Disposal")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/janitor(src)
 			hands.icon_state = "janitor"
 			switch(icontype)
 				if("Janiborg")
@@ -306,11 +292,9 @@
 			feedback_inc("cyborg_janitor",1)
 
 		if("Clown")
+			module = new /obj/item/weapon/robot_module/clown(src)
 			var/icontype = input("Select an icon!", "Robot", "Clown") in list("Clown", "Wizard Bot", "Wizard Borg","Chicken")
 			if(!icontype) return
-			if(module)
-				return
-			module = new /obj/item/weapon/robot_module/clown(src)
 			hands.icon_state = "standard"
 			switch(icontype)
 				if("Clown")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -158,6 +158,8 @@
 		if("Standard")
 			var/icontype = input("Select an icon!", "Robot", "Standard") in list("Standard")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/standard(src)
 			hands.icon_state = "standard"
 			switch(icontype)
@@ -171,6 +173,8 @@
 		if("Service")
 			var/icontype = input("Select an icon!", "Robot", "Butler") in list("Waitress", "Bro", "Butler", /*"Kent",*/ "Rich")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/butler(src)
 			hands.icon_state = "service"
 			switch(icontype)
@@ -194,6 +198,8 @@
 		if("Miner")
 			var/icontype = input("Select an icon!", "Robot", "Tread Miner") in list("Tread Miner")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/miner(src)
 			hands.icon_state = "miner"
 			switch(icontype)
@@ -209,6 +215,8 @@
 		if("Medical")
 			var/icontype = input("Select an icon!", "Robot", "Mediborg") in list("Mediborg" , "Medihover", "Smile Screen")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/medical(src)
 			hands.icon_state = "medical"
 			switch(icontype)
@@ -230,6 +238,8 @@
 		if("Security")
 			var/icontype = input("Select an icon!", "Robot", "Secborg") in list("Secborg", "Treaded Secborg", "Interceptor")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/security(src)
 			hands.icon_state = "security"
 			switch(icontype)
@@ -252,6 +262,8 @@
 		if("Engineering")
 			var/icontype = input("Select an icon!", "Robot", "Engiborg") in list("Engiborg", "Treaded Engiborg", "Hover Engiborg")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/engineering(src)
 			hands.icon_state = "engineer"
 			switch(icontype)
@@ -276,6 +288,8 @@
 		if("Janitor")
 			var/icontype = input("Select an icon!", "Robot", "Janiborg") in list("Janiborg", "Disposal")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/janitor(src)
 			hands.icon_state = "janitor"
 			switch(icontype)
@@ -294,6 +308,8 @@
 		if("Clown")
 			var/icontype = input("Select an icon!", "Robot", "Clown") in list("Clown", "Wizard Bot", "Wizard Borg","Chicken")
 			if(!icontype) return
+			if(module)
+				return
 			module = new /obj/item/weapon/robot_module/clown(src)
 			hands.icon_state = "standard"
 			switch(icontype)


### PR DESCRIPTION
Refer to issue #1074.
### Intent of your Pull Request

Prevents borgs from using multiple open Select Module windows to change modules on the fly, while keeping all the stuff in the hotbar. Changes you into the first selected module, everything else is disregarded (even if you can still click on stuff).

I am not sure if there's a better way to do this other than endless returns everywhere. I really don't want to define a new variable in_use or something in borgs just for this.

EDIT: Thanks to Nirnael (@fizzle7) for pointing me into the right direction and avoiding all the returns.
