### PR TITLE
Captains Announcement is NOT exploitable

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -573,6 +573,8 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 
 /obj/machinery/computer/communications/proc/make_announcement(mob/living/user, is_silicon)
 	var/input = stripped_input(user, "Please choose a message to announce to the station crew.", "What?")
+	if(ai_message_cooldown || message_cooldown)
+		return
 	if(!input || !user.canUseTopic(src))
 		return
 	if(is_silicon)


### PR DESCRIPTION
Refer to issue #1076 .
### Intent of your Pull Request

Prevents sending announcement if console on cooldown if it has sent a message recently.
