### PR TITLE
Fixes silicons accidentaly stating the wrong laws

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -6,6 +6,7 @@
 	var/list/supplied = list()
 	var/list/ion = list()
 	var/mob/living/silicon/owner
+	var/timeLastChanged = 0
 
 /datum/ai_laws/default/asimov
 	name = "Three Laws of Robotics"
@@ -172,31 +173,38 @@
 
 /datum/ai_laws/proc/set_zeroth_law(law, law_borg = null)
 	src.zeroth = law
+	timeLastChanged = world.time
 	if(law_borg) //Making it possible for slaved borgs to see a different law 0 than their AI. --NEO
 		src.zeroth_borg = law_borg
 
 /datum/ai_laws/proc/add_inherent_law(law)
 	if (!(law in src.inherent))
 		src.inherent += law
+		timeLastChanged = world.time
 
 /datum/ai_laws/proc/add_ion_law(law)
 	src.ion += law
+	timeLastChanged = world.time
 
 /datum/ai_laws/proc/clear_inherent_laws()
 	qdel(src.inherent)
 	src.inherent = list()
+	timeLastChanged = world.time
 
 /datum/ai_laws/proc/add_supplied_law(number, law)
 	while (src.supplied.len < number + 1)
 		src.supplied += ""
 
 	src.supplied[number + 1] = law
+	timeLastChanged = world.time
 
 /datum/ai_laws/proc/clear_supplied_laws()
 	src.supplied = list()
+	timeLastChanged = world.time
 
 /datum/ai_laws/proc/clear_ion_laws()
 	src.ion = list()
+	timeLastChanged = world.time
 
 /datum/ai_laws/proc/show_laws(who)
 
@@ -226,6 +234,7 @@
 	if(force)
 		src.zeroth = null
 		src.zeroth_borg = null
+		timeLastChanged = world.time
 		return
 	else
 		if(src.owner.mind.special_role)
@@ -233,6 +242,7 @@
 		else
 			src.zeroth = null
 			src.zeroth_borg = null
+			timeLastChanged = world.time
 			return
 
 /datum/ai_laws/proc/associate(mob/living/silicon/M)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -204,8 +204,11 @@
 		checklaws()
 
 	if (href_list["laws"]) // With how my law selection code works, I changed statelaws from a verb to a proc, and call it through my law selection panel. --NeoFite
-		statelaws()
-
+		if(text2num(href_list["time"]) > laws.timeLastChanged)
+			statelaws()
+		else
+			src << "<span class='warning'>Your laws have changed since you tried to state them, please review them again.</span>"
+			checklaws()
 	return
 
 
@@ -292,7 +295,7 @@
 				src.lawcheck[number+1] = "Yes"
 			list += {"<A href='byond://?src=\ref[src];lawc=[number]'>[src.lawcheck[number+1]] [number]:</A> [law]<BR>"}
 			number++
-	list += {"<br><br><A href='byond://?src=\ref[src];laws=1'>State Laws</A>"}
+	list += {"<br><br><A href='byond://?src=\ref[src];laws=1;time=[world.time]'>State Laws</A>"}
 
 	usr << browse(list, "window=laws")
 


### PR DESCRIPTION
### Intent of your Pull Request

:cl:
rscadd: Silicons are now notified and prevented from stating their laws if their laws have been changed since they opened the "state laws" dialogue.
/:cl:

I saw a round today where a subverted cyborg tried to state its laws without stating the uploaded freeform law. After it opened the dialogue but before it pressed the button to state laws, its core laws were purged, so it ended up stating the freeform law.
