### PR TITLE
Ports Saline-Glucose replenishing your blood (+INJECT method of application)

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -482,7 +482,7 @@
 				if(reagent_id == "internal_beaker")
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)
 						var/fraction = min(injection_amount/reagent_glass.reagents.total_volume, 1)
-						reagent_glass.reagents.reaction(patient, INGEST, fraction)
+						reagent_glass.reagents.reaction(patient, INJECT, fraction)
 						reagent_glass.reagents.trans_to(patient,injection_amount) //Inject from beaker instead.
 				else
 					patient.reagents.add_reagent(reagent_id,injection_amount)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -109,7 +109,7 @@
 					// speed up transfer on blood packs
 					transfer_amount = 10
 				var/fraction = min(transfer_amount/beaker.volume, 1) //the fraction that is transfered of the total volume
-				beaker.reagents.reaction(attached, INGEST, fraction,0) //make reagents reacts, but don't spam messages
+				beaker.reagents.reaction(attached, INJECT, fraction,0) //make reagents reacts, but don't spam messages
 				beaker.reagents.trans_to(attached, transfer_amount)
 				update_icon()
 

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
@@ -20,7 +20,7 @@
 		spawn(70)
 			if(reagents.total_volume)
 				var/fraction = min(a_transfer/reagents.total_volume, 1)
-				reagents.reaction(H, INGEST, fraction)
+				reagents.reaction(H, INJECT, fraction)
 			reagents.trans_id_to(H, "radium", a_transfer)
 			H << "<span class='danger'>You are beginning to feel the after-effect of the injection.</span>"
 		a_boost--

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -1,9 +1,10 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
 var/const/TOUCH = 1 //splashing
-var/const/INGEST = 2 //injection, ingestion
+var/const/INGEST = 2 //ingestion
 var/const/VAPOR = 3 //smoke, foam, spray, blob attack
 var/const/PATCH = 4 //patches
+var/const/INJECT = 5 //injection
 
 ///////////////////////////////////////////////////////////////////////////////////
 

--- a/code/modules/reagents/Chemistry-Readme.dm
+++ b/code/modules/reagents/Chemistry-Readme.dm
@@ -69,7 +69,8 @@ About the Holder:
 			This proc calls the appropriate reaction procs of the reagents.
 			I.e. if A is an object, it will call the reagents reaction_obj
 			proc. The method var is used for reaction on mobs. It simply tells
-			us if the mob TOUCHed the reagent, if it INGESTed the reagent, if the reagent was VAPORIZEd on them, or transfered via a PATCH to them..
+			us if the mob TOUCHed the reagent, if it INGESTed the reagent, if the
+			reagent was VAPORIZEd on them, if the reagent was INJECTed or transfered via a PATCH to them.
 			Since the volume can be checked in a reagents proc, you might want to
 			use the volume_modifier var to modifiy the passed value without actually
 			changing the volume of the reagents.

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -228,7 +228,7 @@
 /datum/reagent/medicine/salglu_solution
 	name = "Saline-Glucose Solution"
 	id = "salglu_solution"
-	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage."
+	description = "Has a 33% chance per metabolism cycle to heal brute and burn damage. Can be used as a blood substitute on an IV drip."
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
@@ -238,6 +238,17 @@
 		M.adjustBruteLoss(-0.5*REM)
 		M.adjustFireLoss(-0.5*REM)
 	..()
+
+/datum/reagent/medicine/salglu_solution/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	if(iscarbon(M) && method == INJECT)
+		var/mob/living/carbon/human/H = M
+		//The lower the blood of the patient, the better it is as a blood substitute.
+		var/efficiency = (560-H.vessel.get_reagent_amount("blood"))/700 + 0.2
+		efficiency = min(0.75,efficiency)
+		//As it's designed for an IV drip, make large injections not as effective as repeated small injections.
+		H.vessel.add_reagent("blood", efficiency * min(5,reac_volume))
+	..()
+
 
 /datum/reagent/medicine/mine_salve
 	name = "Miner's Salve"

--- a/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Other-Reagents.dm
@@ -15,7 +15,7 @@
 
 			if(method == TOUCH || method == VAPOR)
 				M.ContractDisease(D)
-			else //ingest or patch
+			else //ingest, patch or injection
 				M.ForceContractDisease(D)
 
 /datum/reagent/blood/on_new(list/data)
@@ -95,7 +95,7 @@
 
 /datum/reagent/vaccine/reaction_mob(mob/M, method=TOUCH, reac_volume)
 	var/datum/reagent/vaccine/self = src
-	if(islist(self.data) && method == INGEST)
+	if(islist(self.data) && (method == INGEST || method == INJECT))
 		for(var/datum/disease/D in M.viruses)
 			if(D.GetDiseaseID() in self.data)
 				D.cure()
@@ -689,7 +689,7 @@
 					F.overlays -= F.wet_overlay
 
 /datum/reagent/space_cleaner/reaction_mob(mob/M, method=TOUCH, reac_volume)
-	if(method == TOUCH || VAPOR)
+	if(method == TOUCH || method == VAPOR)
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
 			C.color = initial(C.color)
@@ -757,7 +757,7 @@
 	color = "#535E66" // rgb: 83, 94, 102
 
 /datum/reagent/nanites/reaction_mob(mob/M, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
-	if(method==PATCH || method==INGEST || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
+	if(method == PATCH || method == INGEST || method == INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		M.ForceContractDisease(new /datum/disease/transformation/robot(0))
 
 /datum/reagent/xenomicrobes
@@ -767,7 +767,7 @@
 	color = "#535E66" // rgb: 83, 94, 102
 
 /datum/reagent/xenomicrobes/reaction_mob(mob/M, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
-	if(method==PATCH || method==INGEST || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
+	if(method == PATCH || method == INGEST || method == INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
 		M.ContractDisease(new /datum/disease/transformation/xeno(0))
 
 /datum/reagent/fluorosurfactant//foam precursor

--- a/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Pyrotechnic-Reagents.dm
@@ -68,7 +68,7 @@
 
 /datum/reagent/clf3/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(istype(M))
-		if(method != INGEST)
+		if(method != INGEST && method != INJECT)
 			M.adjust_fire_stacks(min(reac_volume/5, 10))
 			M.IgniteMob()
 			PoolOrNew(/obj/effect/hotspot, M.loc)
@@ -153,7 +153,7 @@
 
 /datum/reagent/napalm/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
 	if(istype(M))
-		if(method != INGEST)
+		if(method != INGEST && method != INJECT)
 			M.adjust_fire_stacks(min(reac_volume/4, 20))
 
 /datum/reagent/cryostylane

--- a/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Toxin-Reagents.dm
@@ -33,7 +33,7 @@
 		return
 	if(!istype(M) || !M.dna)
 		return  //No robots, AIs, aliens, Ians or other mobs should be affected by this.
-	if((method==VAPOR && prob(min(33, reac_volume))) || method==INGEST || method == PATCH)
+	if((method == VAPOR && prob(min(33, reac_volume))) || method == INGEST || method == PATCH || method == INJECT)
 		randmuti(M)
 		if(prob(98))
 			randmutb(M)
@@ -484,7 +484,7 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 	toxpwr = 0
 
 /datum/reagent/toxin/itching_powder/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
-	if(method != INGEST)
+	if(method == TOUCH || method == VAPOR)
 		M.reagents.add_reagent("itching_powder", reac_volume)
 
 /datum/reagent/toxin/itching_powder/on_mob_life(mob/living/M)
@@ -687,10 +687,13 @@ datum/reagent/toxin/mutetoxin //the new zombie powder.
 	if(!istype(C))
 		return
 	reac_volume = round(reac_volume,0.1)
-	if(method == INGEST)
-		C.take_organ_damage(min(6*toxpwr, reac_volume * toxpwr))
-		return
-	C.acid_act(acidpwr, toxpwr, reac_volume)
+	switch(method)
+		if(INGEST)
+			C.adjustBruteLoss(min(6*toxpwr, reac_volume * toxpwr))
+		if(INJECT)
+			C.adjustBruteLoss(1.5 * min(6*toxpwr, reac_volume * toxpwr))
+		else
+			C.acid_act(acidpwr, toxpwr, reac_volume)
 
 /datum/reagent/toxin/acid/reaction_obj(obj/O, reac_volume)
 	if(istype(O.loc, /mob)) //handled in human acid_act()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -93,7 +93,7 @@ Borg Hypospray
 		M << "<span class='warning'>You feel a tiny prick!</span>"
 		user << "<span class='notice'>You inject [M] with the injector.</span>"
 		var/fraction = min(amount_per_transfer_from_this/R.total_volume, 1)
-		R.reaction(M, INGEST, fraction)
+		R.reaction(M, INJECT, fraction)
 		if(M.reagents)
 			var/trans = R.trans_to(M, amount_per_transfer_from_this)
 			user << "<span class='notice'>[trans] unit\s injected.  [R.total_volume] unit\s remaining.</span>"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -26,7 +26,7 @@
 		user << "<span class='notice'>You inject [M] with [src].</span>"
 
 		var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
-		reagents.reaction(M, INGEST, fraction)
+		reagents.reaction(M, INJECT, fraction)
 		if(M.reagents)
 			var/list/injected = list()
 			var/viruslist = ""

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -171,7 +171,7 @@
 					investigate_log("[user.name] ([user.ckey]) injected [M.name] ([M.ckey]) with [viruslist]", "viro")
 				add_logs(user, M, "injected", object="[src.name]", addition="which had [contained]")
 				var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
-				reagents.reaction(target, INGEST, fraction)
+				reagents.reaction(target, INJECT, fraction)
 			if(ismob(target) && target == user)
 				//Attack log entries are produced here due to failure to produce elsewhere. Remove them here if you have doubles from normal syringes.
 				var/list/rinject = list()
@@ -182,7 +182,7 @@
 				log_attack("<font color='red'>[user.name] ([user.ckey]) injected [M.name] ([M.ckey]) with [src.name], which had [contained] (INTENT: [uppertext(user.a_intent)])</font>")
 				M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Injected themselves ([contained]) with [src.name].</font>")
 				var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
-				reagents.reaction(target, INGEST, fraction)
+				reagents.reaction(target, INJECT, fraction)
 
 			if(ismob(target))
 				var/mob/M = target


### PR DESCRIPTION
Refer to issue #1095 .
### Intent of your Pull Request

You know, giving a way to replenish blood other than bloodbags (which are still more efficient) is a pretty damn good idea.

Ports these PR's from /tg/ made by @lordpidey
https://github.com/tgstation/-tg-station/pull/12921 - Saline-Glucose now replenishes blood (lower your bloodlevels, the more efficient the transfusion)
https://github.com/tgstation/-tg-station/pull/12700 - Adds new method of reagent application INJECT

:cl: LordPidey
rscadd: Saline-Glucose Solution can now be used as a blood replacement (the lower your blood amount, the more effective this is). Must be applied via injection (IV Drip or Syringe). Ported by X-TheDark.
/:cl:
