### PR TITLE
Ninja spawns after 25 minutes

### DIFF
--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -14,7 +14,8 @@ Contents:
 	name = "Space Ninja"
 	typepath = /datum/round_event/ninja
 	max_occurrences = 1
-	earliest_start = 30000 // 1 hour
+	earliest_start = 15000 // 25 minutes
+	weight = 10 //Added so it's clear what the relative weight is without needing to search
 
 
 /datum/round_event/ninja


### PR DESCRIPTION
Refer to issue #1101.
### Intent of your Pull Request

Ninja now spawns after 25 minutes. Also added weight (which was unchanged), just so it's clear what the relative probability of the event is.

:cl: X-TheDark
tweak: Ninjas now can spawn after 25 minutes (down from 50)
/:cl:
