### PR TITLE
Fixes some mindslave bugs with real_name

### DIFF
--- a/code/game/objects/items/weapons/implants/implantmindslave.dm
+++ b/code/game/objects/items/weapons/implants/implantmindslave.dm
@@ -37,17 +37,17 @@
 		holder << "<span class='warning'>[target] seems to resist the implant!</span>"
 		return 0
 
-	target << "<span class='userdanger'><FONT size = 3>You feel a strange urge to serve [holder]. A simple thought about disobeying his/her commands makes your head feel like it is going to explode. You feel like you dont want to know what will happen if you actually disobey your new master.</FONT></span>"
+	target << "<span class='userdanger'><FONT size = 3>You feel a strange urge to serve [holder.real_name]. A simple thought about disobeying his/her commands makes your head feel like it is going to explode. You feel like you dont want to know what will happen if you actually disobey your new master.</FONT></span>"
 
 	var/datum/objective/mindslave/serve_objective = new
 	serve_objective.owner = target
-	serve_objective.explanation_text = "Serve [holder] no matter what!"
+	serve_objective.explanation_text = "Serve [holder.real_name] no matter what!"
 	serve_objective.completed = 1
 	source.mind.objectives += serve_objective
 	if(!ticker.mode.traitors.Find(source.mind))
 		ticker.mode.traitors += source.mind
 
-	log_game("[holder] enslaved [target] with a Mindslave implant")
+	log_game("[holder.ckey] enslaved [target.ckey] with a Mindslave implant")
 
 	return ..()
 

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -416,7 +416,7 @@
 	G.dna.species.auto_equip(G)
 	G.loc = src.loc
 	G.key = ghost.key
-	G << "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost."
+	G << "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user.real_name], and assist them in completing their goals at any cost."
 	G.mind.store_memory("<b>Serve [user.real_name], your creator.</b>")
 	if(user.mind.special_role)
 		message_admins("[G.real_name] has been summoned by [user.real_name], an antagonist.")


### PR DESCRIPTION
Game log logged the players name and not their Ckey.
Mindslave implant used the `name` variable instead of `real_name` meaning that you could wear someone elses ID to confuse the implant.

:cl:
bugfix: Mindslave implant is no longer fooled by wearing someone elses ID.
/:cl:
