### PR TITLE
Ports chameleon HUD's from /tg/

### DIFF
--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -106,6 +106,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 	var/obj/item/device/gangtool/gangtool = new(mob)
 	var/obj/item/weapon/pen/gang/T = new(mob)
 	var/obj/item/toy/crayon/spraycan/gang/SC = new(mob,gang)
+	var/obj/item/clothing/glasses/hud/security/chameleon/C = new(mob,gang)
 
 	var/list/slots = list (
 		"backpack" = slot_in_backpack,
@@ -139,8 +140,14 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 		. += 1
 	else
 		mob << "The <b>territory spraycan</b> in your [where3] can be used to claim areas of the station for your gang. The more territory your gang controls, the more influence you get. All gangsters can use these, so distribute them to grow your influence faster."
-	mob.update_icons()
 
+	var/where4 = mob.equip_in_one_of_slots(C, slots)
+	if (!where4)
+		mob << "Your Syndicate benefactors were unfortunately unable to get you a chameleon security HUD."
+		. += 1
+	else
+		mob << "The <b>chameleon security HUD</b> in your [where4] will help you keep track of who is loyalty-implanted, and unable to be recruited."
+	mob.update_icons()
 	return .
 
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -237,3 +237,53 @@
 	icon_state = "redglasses"
 	item_state = "redglasses"
 
+/obj/item/clothing/glasses/proc/chameleon(var/mob/user)
+	var/input_glasses = input(user, "Choose a piece of eyewear to disguise as.", "Choose glasses style.") as null|anything in list("Sunglasses", "Medical HUD", "Mesons", "Science Goggles", "Glasses", "Security Sunglasses","Eyepatch","Welding","Gar")
+
+	if(user && src in user.contents)
+		switch(input_glasses)
+			if("Sunglasses")
+				desc = "Strangely ancient technology used to help provide rudimentary eye cover. Enhanced shielding blocks many flashes."
+				name = "sunglasses"
+				icon_state = "sun"
+				item_state = "sunglasses"
+			if("Medical HUD")
+				name = "Health Scanner HUD"
+				desc = "A heads-up display that scans the humans in view and provides accurate data about their health status."
+				icon_state = "healthhud"
+				item_state = "healthhud"
+			if("Mesons")
+				name = "Optical Meson Scanner"
+				desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
+				icon_state = "meson"
+				item_state = "meson"
+			if("Science Goggles")
+				name = "Science Goggles"
+				desc = "A pair of snazzy goggles used to protect against chemical spills."
+				icon_state = "purple"
+				item_state = "glasses"
+			if("Glasses")
+				name = "Prescription Glasses"
+				desc = "Made by Nerd. Co."
+				icon_state = "glasses"
+				item_state = "glasses"
+			if("Security Sunglasses")
+				name = "HUDSunglasses"
+				desc = "Sunglasses with a HUD."
+				icon_state = "sunhud"
+				item_state = "sunglasses"
+			if("Eyepatch")
+				name = "eyepatch"
+				desc = "Yarr."
+				icon_state = "eyepatch"
+				item_state = "eyepatch"
+			if("Welding")
+				name = "welding goggles"
+				desc = "Protects the eyes from welders; approved by the mad scientist association."
+				icon_state = "welding-g"
+				item_state = "welding-g"
+			if("Gar")
+				desc = "Just who the hell do you think I am?!"
+				name = "gar glasses"
+				icon_state = "gar"
+				item_state = "gar"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -46,6 +46,14 @@
 	icon_state = "securityhud"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
 
+/obj/item/clothing/glasses/hud/security/chameleon
+	name = "Chamleon Security HUD"
+	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."
+	flash_protect = 1
+
+/obj/item/clothing/glasses/hud/security/chameleon/attack_self(mob/user)
+	chameleon(user)
+
 /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch
 	name = "Eyepatch HUD"
 	desc = "A heads-up display that connects directly to the optical nerve of the user, replacing the need for that useless eyeball."


### PR DESCRIPTION
Refer to issue #898.
https://forums.yogstation.net/index.php?threads/gang-chameleon-huds.8797/
### Intent of your Pull Request

[tgstation/-tg-station#10873](https://github.com/tgstation/-tg-station/pull/10873)

Chameleon HUD's operate just like sechuds, but they can also be camoflauged to look like other types of glasses.

Gang heads will spawn with these, they are **not** buyable.

:cl:KorPhaeron
rscadd: The Syndicate has re-engineered a stolen sechud, it operates like a normal one but can be camouflaged! It is currently being exported to gang leaders to cause strategic panic on the station!
rscadd: Chameleon HUD's have been added, port by Super3222.
/:cl:
