### PR TITLE
Giving the rev flash and hijacker tech levels.

### DIFF
--- a/code/game/gamemodes/revolution/rev_flash.dm
+++ b/code/game/gamemodes/revolution/rev_flash.dm
@@ -5,6 +5,7 @@
 	desc = "You aren't sure what this thing does, but you're almost certain that it can't be good."
 	icon_state = "memorizer"
 	item_state = "nullrod"
+	origin_tech = "syndicate=1;combat=2"
 
 	var/cooldown = 0
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -428,3 +428,4 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implanter1"
 	item_state = "syringe_0"
+	origin_tech = "magnets=6;syndicate=3"

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -428,4 +428,4 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "implanter1"
 	item_state = "syringe_0"
-	origin_tech = "magnets=6;syndicate=3"
+	origin_tech = "magnets=7;syndicate=1"


### PR DESCRIPTION
Refer to issue #1014 where I clearly did not completely comprehend the hijacker.
### Intent of your Pull Request

Rev flashes will gain level 1 illegal tech and level 2 combat.

Rev HIJACKERS will gain level 6 electromagnetic and level 3 illegal.

:cl:Super3222
rscadd: Rev Flash can be deconstructed in R&D for level 2 combat and level 1 illegal tech.
rscadd: Revolution Hijacker tools can be deconstructed in R&D for level 6 magnet and level 3 illegal tech.
/:cl:
