### PR TITLE
Fixes double eswords not having armor pen

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -26,6 +26,8 @@
 	var/force_wielded = 0
 	var/wieldsound = null
 	var/unwieldsound = null
+	var/armourpenetration_wielded = 0
+	var/armourpenetration_unwielded = 0
 
 /obj/item/weapon/twohanded/proc/unwield(mob/living/carbon/user)
 	if(!wielded || !user) return
@@ -55,6 +57,7 @@
 		return
 	wielded = 1
 	force = force_wielded
+	armour_penetration = armourpenetration_wielded
 	name = "[name] (Wielded)"
 	update_icon()
 	user << "<span class='notice'>You grab the [name] with both hands.</span>"
@@ -190,6 +193,8 @@
 	w_class = 2.0
 	force_unwielded = 3
 	force_wielded = 34
+	armourpenetration_wielded = 10
+	armourpenetration_unwielded = 0
 	wieldsound = 'sound/weapons/saberon.ogg'
 	unwieldsound = 'sound/weapons/saberoff.ogg'
 	hitsound = "swing_hit"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -33,6 +33,7 @@
 	if(!wielded || !user) return
 	wielded = 0
 	force = force_unwielded
+	armour_penetration = armourpenetration_unwielded
 	var/sf = findtext(name," (Wielded)")
 	if(sf)
 		name = copytext(name,1,sf)


### PR DESCRIPTION
as it should have happened in #912

an oversight on my part

:cl: FluffySurvivor 
bugfix: Double eswords are now properly granted armor penetration. 
/:cl:
