### PR TITLE
Fixed bug in slime life code

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -152,6 +152,7 @@
 	if(..())
 		if(prob(30))
 			adjustBruteLoss(-1)
+		return 1
 
 /mob/living/simple_animal/slime/proc/handle_nutrition()
 


### PR DESCRIPTION
### Intent of your Pull Request

:cl:
bugfix: Slimes are no longer blinded forever by statues.
/:cl:

Slimes were being permanently blinded by statues. Upon investigation it was because handle_regular_status_updates() was not returning 1 when it should have been. Slimes are now immune to temporary blinding effects like all other simple animals. Hopefully this has no unintended side effects.
