### PR TITLE
Rules broken are now added to ban reason

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -919,6 +919,7 @@
 					var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
 					if(!rules_broken)
 						return
+					reason += " ([rules_broken])"
 
 					var/msg
 					for(var/job in notbannedlist)
@@ -945,6 +946,7 @@
 						return
 					var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
 					if(rules_broken)
+						reason += " ([rules_broken])"
 						var/msg
 						for(var/job in notbannedlist)
 							ban_unban_log_save("[key_name(usr)] perma-jobbanned [key_name(M)] from [job]. reason: [reason]")
@@ -1110,6 +1112,7 @@
 				var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
 				if(!rules_broken)
 					return
+				reason += " ([rules_broken])"
 				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
 				ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.")
 				M << "<span class='boldannounce'><BIG>You have been banned by [usr.client.ckey].\nReason: [reason]</BIG></span>"
@@ -1134,6 +1137,7 @@
 				var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
 				if(!rules_broken)
 					return
+				reason += " ([rules_broken])" //add them to the ban reasons.
 				switch(alert(usr,"IP ban?",,"Yes","No","Cancel"))
 					if("Cancel")	return
 					if("Yes")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -916,6 +916,9 @@
 					var/reason = input(usr,"Reason?","Please State Reason","") as text|null
 					if(!reason)
 						return
+					var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
+					if(!rules_broken)
+						return
 
 					var/msg
 					for(var/job in notbannedlist)
@@ -938,7 +941,10 @@
 					return 1
 				if("No")
 					var/reason = input(usr,"Reason?","Please State Reason","") as text|null
-					if(reason)
+					if(!reason)
+						return
+					var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
+					if(rules_broken)
 						var/msg
 						for(var/job in notbannedlist)
 							ban_unban_log_save("[key_name(usr)] perma-jobbanned [key_name(M)] from [job]. reason: [reason]")
@@ -953,6 +959,7 @@
 						message_admins("<span class='adminnotice'>[key_name_admin(usr)] banned [key_name_admin(M)] from [msg]</span>")
 						M << "<span class='boldannounce'><BIG>You have been jobbanned by [usr.client.ckey] from: [msg].</BIG></span>"
 						M << "<span class='boldannounce'>The reason is: [reason]</span>"
+						M << "<span class='danger'>The broken rules were '[rules_broken]'. You should keep this information for eventual ban appeals.</span>"
 						M << "<span class='danger'>Jobban can be lifted only upon request.</span>"
 						href_list["jobban2"] = 1 // lets it fall through and refresh
 						return 1
@@ -1100,9 +1107,13 @@
 				var/reason = input(usr,"Reason?","reason","Griefer") as text|null
 				if(!reason)
 					return
+				var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
+				if(!rules_broken)
+					return
 				AddBan(M.ckey, M.computer_id, reason, usr.ckey, 1, mins)
 				ban_unban_log_save("[usr.client.ckey] has banned [M.ckey]. - Reason: [reason] - This will be removed in [mins] minutes.")
 				M << "<span class='boldannounce'><BIG>You have been banned by [usr.client.ckey].\nReason: [reason]</BIG></span>"
+				M << "<span class='danger'>The broken rules were '[rules_broken]'. You should keep this information for eventual ban appeals.</span>"
 				M << "<span class='danger'>This is a temporary ban, it will be removed in [mins] minutes.</span>"
 				feedback_inc("ban_tmp",1)
 				DB_ban_record(BANTYPE_TEMP, M, mins, reason)
@@ -1120,6 +1131,9 @@
 				var/reason = input(usr,"Reason?","reason","Griefer") as text|null
 				if(!reason)
 					return
+				var/rules_broken = input(usr,"Which rule did they break? (Rule broken number.)",,"0.0") as text|null
+				if(!rules_broken)
+					return
 				switch(alert(usr,"IP ban?",,"Yes","No","Cancel"))
 					if("Cancel")	return
 					if("Yes")
@@ -1127,6 +1141,7 @@
 					if("No")
 						AddBan(M.ckey, M.computer_id, reason, usr.ckey, 0, 0)
 				M << "<span class='boldannounce'><BIG>You have been banned by [usr.client.ckey].\nReason: [reason]</BIG></span>"
+				M << "<span class='danger'>The broken rules were '[rules_broken]'. You should keep this information for eventual ban appeals.</span>"
 				M << "<span class='danger'>This is a permanent ban.</span>"
 				if(config.banappeals)
 					M << "<span class='danger'>To try to resolve this matter head to [config.banappeals]</span>"


### PR DESCRIPTION
Adds a new text prompt for when bans are added which specifies which rule a player has broken.

![image](https://cloud.githubusercontent.com/assets/13056792/15229296/ac6d8aca-1890-11e6-8cbb-7c6f01130290.png)

Image above is nearly respective of what it looks like ingame.

[https://forums.yogstation.net/index.php?threads/vote-should-ban-reasons-have-which-rules-bans-are-based-on-stated-in-them.10454/](https://forums.yogstation.net/index.php?threads/vote-should-ban-reasons-have-which-rules-bans-are-based-on-stated-in-them.10454/)

:cl:AsV9
tweak: Slight change to bans, ban reasons will now have a rule attached to them for reference in ban appeals. 
/:cl:
