### PR TITLE
Adds autoimplanter to nukeops cybernetic implants

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -736,32 +736,32 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/cyber_implants/thermals
 	name = "Thermal Vision Implant"
-	desc = "These cybernetic eyes will give you thermal vision."
-	item = /obj/item/organ/internal/cyberimp/eyes/thermals
+	desc = "These cybernetic eyes will give you thermal vision. Comes with an autoimplanter."
+	item = /obj/item/weapon/storage/box/cyber_implants/thermals
 	cost = 8
 
 /datum/uplink_item/cyber_implants/xray
 	name = "X-Ray Vision Implant"
-	desc = "These cybernetic eyes will give you X-ray vision."
-	item = /obj/item/organ/internal/cyberimp/eyes/xray
+	desc = "These cybernetic eyes will give you X-ray vision. Comes with an autoimplanter."
+	item = /obj/item/weapon/storage/box/cyber_implants/xray
 	cost = 10
 
 /datum/uplink_item/cyber_implants/antistun
 	name = "CNS Rebooter Implant"
-	desc = "This implant will help you get back up on your feet faster after being stunned."
-	item = /obj/item/organ/internal/cyberimp/brain/anti_stun
+	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autoimplanter."
+	item = /obj/item/weapon/storage/box/cyber_implants/antistun
 	cost = 12
 
 /datum/uplink_item/cyber_implants/reviver
 	name = "Reviver Implant"
-	desc = "This implant will attempt to revive you if you lose consciousness."
-	item = /obj/item/organ/internal/cyberimp/chest/reviver
+	desc = "This implant will attempt to revive you if you lose consciousness. Comes with an autoimplanter."
+	item = /obj/item/weapon/storage/box/cyber_implants/reviver
 	cost = 8
 
 /datum/uplink_item/cyber_implants/bundle
 	name = "Cybernetic Implants Bundle"
-	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants."
-	item = /obj/item/weapon/storage/box/cyber_implants
+	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autoimplanter."
+	item = /obj/item/weapon/storage/box/cyber_implants/random
 	cost = 40
 
 // POINTLESS BADASSERY

--- a/code/game/objects/autoimplanter.dm
+++ b/code/game/objects/autoimplanter.dm
@@ -1,0 +1,33 @@
+/obj/item/device/autoimplanter
+	name = "autoimplanter"
+	desc = "A device that automatically injects a cyber-implant into the user without the hassle of extensive surgery. It has a slot to insert implants and a screwdriver slot for removing accidentally added implants."
+	icon_state = "gangtool-white"
+	item_state = "walkietalkie"
+	w_class = 2
+	var/obj/item/organ/internal/cyberimp/storedorgan
+
+/obj/item/device/autoimplanter/attack_self(mob/user, obj/item/I)//when the object it used...
+	if(!storedorgan)
+		user << "<span class='notice'>[src] currently has no implant stored.</span>"
+		return
+	storedorgan.Insert(user)//insert stored organ into the user
+	user << "<span class='notice'>You feel a slight tickle as [src] quickly implants you with the [storedorgan].</span>"
+	storedorgan = null
+
+/obj/item/device/autoimplanter/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/organ/internal/cyberimp))
+		if(storedorgan)
+			user << "<span class='notice'>[src] already has an implant stored.</span>"
+			return
+		user.unEquip(I)
+		I.loc = src
+		storedorgan = I
+		user << "<span class='notice'>You insert the [I] into [src].</span>"
+	if(istype(I, /obj/item/weapon/screwdriver))
+		if(!storedorgan)
+			user << "<span class='notice'>There's no implant in [src] for you to remove.</span>"
+		else
+			var/turf/floorloc = get_turf(user)
+			floorloc.contents += contents
+			user << "<span class='notice'>You remove the [storedorgan] from [src].</span>"
+			storedorgan = null

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -257,17 +257,39 @@
 //BOX O' IMPLANTS
 
 /obj/item/weapon/storage/box/cyber_implants
-	name = "boxed cybernetic implants"
+	name = "boxed cybernetic implant"
 	desc = "A sleek, sturdy box."
 	icon_state = "cyber_implants"
-	var/list/boxed = list(/obj/item/organ/internal/cyberimp/eyes/xray,/obj/item/organ/internal/cyberimp/eyes/thermals,
-						/obj/item/organ/internal/cyberimp/brain/anti_stun, /obj/item/organ/internal/cyberimp/chest/reviver)
-	var/amount = 5
+	var/list/implants = list()
 
 /obj/item/weapon/storage/box/cyber_implants/New()
 	..()
+	for(var/type in implants)
+		new type(src)
+	new /obj/item/device/autoimplanter(src)
+
+/obj/item/weapon/storage/box/cyber_implants/random
+	name = "boxed cybernetic implants"
+	var/amount = 5
+	var/list/random_implants = list(/obj/item/organ/internal/cyberimp/eyes/xray,/obj/item/organ/internal/cyberimp/eyes/thermals,
+						/obj/item/organ/internal/cyberimp/brain/anti_stun, /obj/item/organ/internal/cyberimp/chest/reviver)
+
+/obj/item/weapon/storage/box/cyber_implants/random/New()
 	var/i
 	var/implant
 	for(i = 0, i < amount, i++)
-		implant = pick(boxed)
+		implant = pick(random_implants)
 		new implant(src)
+	..()
+
+/obj/item/weapon/storage/box/cyber_implants/thermals
+	implants = list(/obj/item/organ/internal/cyberimp/eyes/thermals)
+
+/obj/item/weapon/storage/box/cyber_implants/xray
+	implants = list(/obj/item/organ/internal/cyberimp/eyes/xray)
+
+/obj/item/weapon/storage/box/cyber_implants/antistun
+	implants = list(/obj/item/organ/internal/cyberimp/brain/anti_stun)
+
+/obj/item/weapon/storage/box/cyber_implants/reviver
+	implants = list(/obj/item/organ/internal/cyberimp/chest/reviver)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -553,6 +553,7 @@
 #include "code\game\mecha\medical\odysseus.dm"
 #include "code\game\mecha\working\ripley.dm"
 #include "code\game\mecha\working\working.dm"
+#include "code\game\objects\autoimplanter.dm"
 #include "code\game\objects\buckling.dm"
 #include "code\game\objects\empulse.dm"
 #include "code\game\objects\explosion.dm"


### PR DESCRIPTION
### Intent of your Pull Request

:cl:
rscadd: Nukeops cybernetic implants now all come with an autoimplanter, removing the need for surgery after purchase.
/:cl:

Ported the autoinjector from @PKPenguin321

Requested by Adam.
