### PR TITLE
Unironically buffs construct cult and makes it more engaging to play as construct (Merge ready)

### DIFF
--- a/code/datums/spells/construct_spells.dm
+++ b/code/datums/spells/construct_spells.dm
@@ -17,7 +17,7 @@
 	invocation = "none"
 	invocation_type = "none"
 	range = 0
-	summon_type = list(/turf/simulated/floor/plasteel/cult)
+	summon_type = list(/turf/simulated/floor/engine/cult)
 	centcom_cancast = 0 //Stop crashing the server by spawning turfs on transit tiles
 
 /obj/effect/proc_holder/spell/aoe_turf/conjure/wall

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -165,7 +165,18 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 
 /turf/simulated/floor/narsie_act()
 	if(prob(20))
-		ChangeTurf(/turf/simulated/floor/plasteel/cult)
+		ChangeTurf(/turf/simulated/floor/engine/cult)
+
+/turf/simulated/floor/attack_animal(mob/living/simple_animal/M)
+	if(istype(M,/mob/living/simple_animal/construct/builder)||istype(M,/mob/living/simple_animal/construct/harvester))
+		if(istype(src, /turf/simulated/floor/engine/cult))
+			return
+		src.ChangeTurf(/turf/simulated/floor/engine/cult)
+		M <<"<span class='notice'>You transfer some of your corrupt energy into the floor, causing it to transform.</span>"
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		return
+	return
+
 
 /turf/simulated/floor/Entered(atom/A, atom/OL)
 	..()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -101,6 +101,13 @@
 
 
 /turf/simulated/wall/attack_animal(mob/living/simple_animal/M)
+	if(istype(M,/mob/living/simple_animal/construct/builder)||istype(M,/mob/living/simple_animal/construct/harvester))
+		if(istype(src, /turf/simulated/wall/cult))
+			return
+		src.ChangeTurf(/turf/simulated/wall/cult)
+		M <<"<span class='notice'>You transfer some of your corrupt energy into the wall, causing it to transform.</span>"
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		return
 	M.changeNext_move(CLICK_CD_MELEE)
 	M.do_attack_animation(src)
 	if(M.environment_smash >= 2)
@@ -108,6 +115,20 @@
 		M << "<span class='notice'>You smash through the wall.</span>"
 		dismantle_wall(1)
 		return
+
+
+/turf/simulated/wall/cult/Bumped(atom/movable/C as mob)
+	var/phasable=0
+	if(istype(C,/mob/living/simple_animal/construct/builder)||istype(C,/mob/living/simple_animal/construct/wraith)||istype(C,/mob/living/simple_animal/construct/harvester))
+		phasable = 2
+		while(phasable>0)
+			src.density = 0
+			sleep(10)
+			phasable--
+		src.density = 1
+	return
+
+
 
 /turf/simulated/wall/attack_hulk(mob/user)
 	..(user, 1)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -37,7 +37,7 @@
 	return
 
 /mob/living/simple_animal/construct/examine(mob/user)
-	var/msg = "<span cass='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n"
+	var/msg = "<span cass='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n[desc]\n"
 	if (src.health < src.maxHealth)
 		msg += "<span class='warning'>"
 		if (src.health >= src.maxHealth/2)
@@ -91,13 +91,15 @@
 	attacktext = "smashes their armored gauntlet into"
 	speed = 3
 	environment_smash = 2
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/punch3.ogg'
 	status_flags = 0
 	mob_size = MOB_SIZE_LARGE
 	force_threshold = 11
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall)
 	playstyle_string = "<B>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, \
-						create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.</B>"
+						create shield walls and even deflect energy weapons, and rip apart enemies and walls alike. You cannot phase through walls created by the Artificer, however.</B>"
 
 /mob/living/simple_animal/construct/armored/bullet_act(obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
@@ -135,7 +137,7 @@
 /mob/living/simple_animal/construct/wraith
 	name = "Wraith"
 	real_name = "Wraith"
-	desc = "A wicked bladed shell contraption piloted by a bound spirit"
+	desc = "A wicked bladed shell contraption piloted by a bound spirit."
 	icon_state = "floating"
 	icon_living = "floating"
 	maxHealth = 75
@@ -144,10 +146,11 @@
 	melee_damage_upper = 25
 	attacktext = "slashes"
 	speed = 0
-	see_in_dark = 7
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
-	playstyle_string = "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</B>"
+	playstyle_string = "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls, including ones made by the Artificer.</B>"
 
 
 
@@ -156,17 +159,19 @@
 /mob/living/simple_animal/construct/builder
 	name = "Artificer"
 	real_name = "Artificer"
-	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies"
+	desc = "A bulbous construct dedicated to building and maintaining The Cult of Nar-Sie's armies."
 	icon_state = "artificer"
 	icon_living = "artificer"
-	maxHealth = 50
-	health = 50
+	maxHealth = 55
+	health = 55
 	response_harm = "viciously beats"
 	harm_intent_damage = 5
 	melee_damage_lower = 5
 	melee_damage_upper = 5
 	attacktext = "rams"
 	speed = 0
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	environment_smash = 2
 	attack_sound = 'sound/weapons/punch2.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/construct/lesser,
@@ -175,6 +180,7 @@
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone,
 							/obj/effect/proc_holder/spell/targeted/projectile/magic_missile/lesser)
 	playstyle_string = "<B>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, \
+						corrupt areas (click on floors and walls to corrupt them and allow you to phase through them), \
 						use magic missile, repair allied constructs (by clicking on them), \
 						</B><I>and most important of all create new constructs</I><B> \
 						(Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
@@ -194,7 +200,8 @@
 	attacktext = "prods"
 	speed = 0
 	environment_smash = 1
-	see_in_dark = 7
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/tap.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/smoke/disable)
 	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -48,3 +48,10 @@
 	. = ..()
 	if((iscultist(user) || iswizard(user)) && (!src.key || !src.client))
 		user << "<span class='danger'>You can also tell that they've lost all conscious awareness and have become as engaging as a blank wall.</span>"
+
+/mob/living/simple_animal/shade/attack_animal(mob/living/simple_animal/M)
+	if(istype(M, /mob/living/simple_animal/construct/builder))
+		adjustBruteLoss(-5)
+		M.emote("me", 1, "mends some of \the <EM>[src]'s</EM> wounds.")
+	else if(src != M)
+		..()


### PR DESCRIPTION
I don't make issues for my PRs, fuck da system
### Intent of your Pull Request

Makes constructs better, basically. 

Changes-

Artificers now have 55 health, up from 40. Still dies from lethal shotguns, but can take more lasers.
Shades can now be healed by artificers.
All constructs have full nightvision, which for some reason they didn't have before.

**THE BIG SHIT**
Artificers and harvesters can now click to corrupt walls and floors, turning them into the cult variant.

Artificers, wraiths, and harvesters can phase through cult walls. You can follow them if you move directly behind them, but you need to be lucky or have them pull you through it. (JUGGERNAUTS CANNOT DO THIS)

Bugfixes-
Fixes Nar'Sie and Artificers not correctly making cult floors
Fixes constructs not showing description on examine

If I forgot something here I apologize
#### Changelog

:cl: ShadowDeath6
rscadd: Cultist constructs known as Artificers and Harvesters can now corrupt floors and walls by attacking them, allowing them to phase through them. Wraiths can also phase through these cult walls, but Juggernauts cannot.
tweak: Artificers have 55 health now, up from 40. They can now survive an additional laser blast.
bugfix: Nar'Sie and Artificers now correctly make cult floors.
bugfix: Fixed constructs not showing an examine description.
tweak: All constructs now have full nightvision.
tweak: Shades can now be healed by Artificers.
/:cl:
