### PR TITLE
Ei nath is no longer round ruining

### DIFF
--- a/code/datums/spells/touch_attacks.dm
+++ b/code/datums/spells/touch_attacks.dm
@@ -50,9 +50,9 @@
 	hand_path = "/obj/item/weapon/melee/touch_attack/disintegrate"
 
 	school = "evocation"
-	charge_max = 600
+	charge_max = 500
 	clothes_req = 1
-	cooldown_min = 200 //100 deciseconds reduction per rank
+	cooldown_min = 100 //100 deciseconds reduction per rank
 
 	action_icon_state = "gib"
 

--- a/code/datums/spells/touch_attacks.dm
+++ b/code/datums/spells/touch_attacks.dm
@@ -46,7 +46,7 @@
 
 /obj/effect/proc_holder/spell/targeted/touch/disintegrate
 	name = "Disintegrate"
-	desc = "This spell charges your hand with vile energy that can be used to violently explode victims."
+	desc = "This spell charges your hand with vile energy that can be used to kill a victim without fail."
 	hand_path = "/obj/item/weapon/melee/touch_attack/disintegrate"
 
 	school = "evocation"

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -43,7 +43,7 @@
 /obj/item/weapon/melee/touch_attack/disintegrate/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || user.lying || user.handcuffed) //exploding after touching yourself would be bad
 		return
-	var/mob/M = target
+	var/mob/living/M = target
 	if(M.stat == DEAD)
 		user <<"<span class='notice'>Your target is already dead.</span>"
 		return
@@ -51,6 +51,7 @@
 	sparks.set_up(4, 0, M.loc) //no idea what the 0 is
 	sparks.start()
 	M.death()
+	M.apply_damage(500, BRUTE)
 	..()
 
 /obj/item/weapon/melee/touch_attack/fleshtostone

--- a/code/game/gamemodes/wizard/godhand.dm
+++ b/code/game/gamemodes/wizard/godhand.dm
@@ -44,17 +44,13 @@
 	if(!proximity || target == user || !ismob(target) || !iscarbon(user) || user.lying || user.handcuffed) //exploding after touching yourself would be bad
 		return
 	var/mob/M = target
-	if(ishuman(M) || ismonkey(M))
-		var/mob/living/carbon/C_target = M
-		var/obj/item/organ/internal/brain/B = C_target.getorgan(/obj/item/organ/internal/brain)
-		if(B)
-			B.loc = get_turf(C_target)
-			B.transfer_identity(C_target)
-			C_target.internal_organs -= B
+	if(M.stat == DEAD)
+		user <<"<span class='notice'>Your target is already dead.</span>"
+		return
 	var/datum/effect/effect/system/spark_spread/sparks = new
 	sparks.set_up(4, 0, M.loc) //no idea what the 0 is
 	sparks.start()
-	M.gib()
+	M.death()
 	..()
 
 /obj/item/weapon/melee/touch_attack/fleshtostone


### PR DESCRIPTION
Refer to issue #1139 .
### Intent of your Pull Request

Ei nath no longer explodes your body and ruins your round if wiz picks up your brain

AND BEFORE YOU SAY "OH SHADOW WIZ IS SUPPOSED TO BE OP"

literally every other spell allows the victim to be recovered

also the cooldown is 50 instead of 60 because direct nerfs are baddu
#### Changelog

:cl:
tweak: The Wizard's Disintegrate spell, also known as Ei Nath, no longer gibs, just kills.
tweak: The cooldown for Disintegrate has been decreased to compensate for its decrease in lethality.
/:cl:
