### PR TITLE
'You're an X' popup

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -75,6 +75,10 @@
 /datum/game_mode/proc/post_setup(report=1)
 	spawn (ROUNDSTART_LOGOUT_REPORT_TIME)
 		display_roundstart_logout_report()
+	for(var/mob/antag in mob_list)
+		if(antag.mind)
+			if(antag.mind.special_role)
+				antag.mind.show_memory(Player)
 
 	feedback_set_details("round_start","[time2text(world.realtime)]")
 	if(ticker && ticker.mode)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -78,7 +78,7 @@
 	for(var/mob/antag in mob_list)
 		if(antag.mind)
 			if(antag.mind.special_role)
-				antag.mind.show_memory(Player)
+				antag.mind.show_memory(antag)
 
 	feedback_set_details("round_start","[time2text(world.realtime)]")
 	if(ticker && ticker.mode)


### PR DESCRIPTION
Refer to issue #1096.
### Intent of your Pull Request

An antagonists notes (containing what you are and your objectives) will popup at the start of the round.
#### Changelog

:cl:Super3222
tweak: When you roll antag at the start of the round, your objectives will pop up.
/:cl:
