### PR TITLE
Fixes package unwrap TK bug

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -69,15 +69,26 @@
 
 
 /obj/item/smallDelivery/attack_self(mob/user)
-	if(wrapped && wrapped.loc) //sometimes items can disappear. For example, bombs. --rastaf0
-		wrapped.loc = user.loc
-		if(ishuman(user))
-			user.put_in_hands(wrapped)
-		else
-			wrapped.loc = get_turf(src)
+	user.unEquip(src)
+	for(var/X in contents)
+		var/atom/movable/AM = X
+		user.put_in_hands(AM)
 	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
 	qdel(src)
 
+/obj/item/smallDelivery/attack_self_tk(mob/user)
+	if(istype(loc, /mob))
+		var/mob/M = loc
+		M.unEquip(src)
+		for(var/X in contents)
+			var/atom/movable/AM = X
+			M.put_in_hands(AM)
+	else
+		for(var/X in contents)
+			var/atom/movable/AM = X
+			AM.forceMove(src.loc)
+	playsound(src.loc, 'sound/items/poster_ripped.ogg', 50, 1)
+	qdel(src)
 
 /obj/item/smallDelivery/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/device/destTagger))


### PR DESCRIPTION
### Intent of your Pull Request

Fixes a bug where you could unwrap a package with telekinesis and the contents would warp to your hands. Also does a small update to package code for edge cases where objects multiply inside the package (stolen from /tg/ naturally).
#### Changelog

:cl:
bugfix: unwrapping a package with telekinesis no longer teleports the contents to your hand.
/:cl:
