### PR TITLE
Remove BYGEX information from the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,3 @@ Finally, to start the server, run Dream Daemon and enter the path to your
 compiled tgstation.dmb file.  Make sure to set the port to the one you 
 specified in the config.txt, and set the Security box to 'Safe'.  Then press GO
 and the server should start up and be ready to join.
-
-###HOSTING ON LINUX
-We use BYGEX for some of our text replacement related code. Unfortunately, we
-only have a windows dll included right now. You can find a version known to compile on linux, along with some basic install instructions here
-https://github.com/optimumtact/byond-regex
-
-Otherwise, edit the file `code/_compile_options.dm`, and comment out:
-`#define USE_BYGEX`
-at the bottom, so that it looks like this:
-`//#define USE_BYGEX`
-Recompile the codebase afterwards.
-
-


### PR DESCRIPTION
With regex handled by BYOND directly, do we really need information about the old system in the readme?
