### PR TITLE
Minebot Fixes

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -634,7 +634,7 @@
 	speak_emote = list("states")
 	wanted_objects = list(/obj/item/weapon/ore/diamond, /obj/item/weapon/ore/gold, /obj/item/weapon/ore/silver,
 						  /obj/item/weapon/ore/plasma,  /obj/item/weapon/ore/uranium,    /obj/item/weapon/ore/iron,
-						  /obj/item/weapon/ore/bananium)
+						  /obj/item/weapon/ore/bananium, /obj/item/weapon/ore/glass)
 
 
 /mob/living/simple_animal/hostile/mining_drone/CanAttack(var/atom/the_target)
@@ -667,7 +667,7 @@
 			if(maxHealth == health)
 				user << "<span class='info'>[src] is at full integrity.</span>"
 			else
-				health += 10
+				adjustBruteLoss(-10)
 				user << "<span class='info'>You repair some of the armor on [src].</span>"
 			return
 	if(istype(I, /obj/item/device/mining_scanner) || istype(I, /obj/item/device/t_scanner/adv_mining_scanner))


### PR DESCRIPTION
### Intent of your Pull Request

Minedrones now chase sand and can be properly healed by welders.
These are for the AI-controlled bot that you buy from the vendor, not minedrones. I bought one and was irritated that it would only pick up sand if the sand was adjacent to and ore piece, and that I could not heal it with my welder.
#### Changelog

:cl:
bugfix: Minebots can now be properly repaired by welders.
tweak: Minebots now pick up sand even when it is not adjacent to ore.
/:cl:
