### PR TITLE
minor ninja update

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -86,6 +86,7 @@
 				//Suit gear
 				stat("Energy Charge:", "[round(SN.cell.charge/100)]%")
 				stat("Smoke Bombs:", "\Roman [SN.s_bombs]")
+				stat("Adrenaline Boosters:", "[SN.a_boost]")
 				//Ninja status
 				if(dna)
 					stat("Fingerprints:", "[md5(dna.uni_identity)]")

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
@@ -15,6 +15,9 @@
 		H.SetWeakened(0)
 
 		H.stat = 0//At least now you should be able to teleport away or shoot ninja stars.
+
+		H << "<span class='notice'>Adrenaline injectors activated.</span>"
+
 		spawn(30)//Slight delay so the enemy does not immedietly know the ability was used. Due to lag, this often came before waking up.
 			H.say(pick("A CORNERED FOX IS MORE DANGEROUS THAN A JACKAL!","HURT ME MOOORRREEE!","IMPRESSIVE!"))
 		spawn(70)
@@ -24,5 +27,6 @@
 			reagents.trans_id_to(H, "radium", a_transfer)
 			H << "<span class='danger'>You are beginning to feel the after-effect of the injection.</span>"
 		a_boost--
+		H << "<span class='notice'>There are <B>[a_boost]</B> adrenaline injectors remaining.</span>"
 		s_coold = 3
 	return


### PR DESCRIPTION
Refer to issue #1101 
### Intent of your Pull Request

Adds a counter for remaining adrenaline charges to SpiderOS tab
Adds an on-use message for ninja adrenaline, because its previous on-use message doesn't trigger until after ability cooldown ends
#### Changelog

:cl:
rscadd: Adds counter for ninja adrenal ability
/:cl:
