### PR TITLE
Buffs Syndicate Tools

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -535,7 +535,7 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/device_tools/toolbox
 	name = "Full Syndicate Toolbox"
-	desc = "The syndicate toolbox is a suspicious black and red. Aside from tools, it comes with cable and a multitool. Insulated gloves are not included."
+	desc = "The syndicate toolbox is a suspicious black and red. It comes with a full set of tools that work 30% faster than the standard variety, as well as a regular multitool and insulated combat gloves."
 	item = /obj/item/weapon/storage/toolbox/syndicate
 	cost = 1
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -77,11 +77,11 @@
 
 /obj/item/weapon/storage/toolbox/syndicate/New()
 	..()
-	new /obj/item/weapon/tool/screwdriver(src, "red")
-	new /obj/item/weapon/tool/wrench(src)
-	new /obj/item/weapon/tool/weldingtool/largetank(src)
-	new /obj/item/weapon/tool/crowbar/red(src)
-	new /obj/item/weapon/tool/wirecutters(src, "red")
+	new /obj/item/weapon/tool/screwdriver/syndicate(src)
+	new /obj/item/weapon/tool/wrench/syndicate(src)
+	new /obj/item/weapon/tool/weldingtool/largetank/syndicate(src)
+	new /obj/item/weapon/tool/crowbar/red/syndicate(src)
+	new /obj/item/weapon/tool/wirecutters/syndicate(src)
 	new /obj/item/device/multitool(src)
 	new /obj/item/clothing/gloves/combat(src)
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -498,3 +498,22 @@
 	throw_range = 3
 	materials = list(MAT_METAL=70)
 	icon_state = "crowbar_large"
+
+/obj/item/weapon/tool/screwdriver/syndicate
+	speed_coefficient = 0.7
+/obj/item/weapon/tool/screwdriver/syndicate/New(location)
+	..(location, "red")
+
+/obj/item/weapon/tool/wirecutters/syndicate
+	speed_coefficient = 0.7
+/obj/item/weapon/tool/wirecutters/syndicate/New(location)
+	..(location, "red")
+
+/obj/item/weapon/tool/wrench/syndicate
+	speed_coefficient = 0.7
+
+/obj/item/weapon/tool/weldingtool/largetank/syndicate
+	speed_coefficient = 0.7
+
+/obj/item/weapon/tool/crowbar/red/syndicate
+	speed_coefficient = 0.7

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -138,23 +138,25 @@
 		return
 
 	if (istype(I, /obj/item/weapon/tool/screwdriver))
+		var/obj/item/weapon/tool/screwdriver/sd = I
 		if(istype(src, /obj/structure/table/reinforced))
 			var/obj/structure/table/reinforced/RT = src
 			if(RT.status == 1)
-				table_destroy(2, user)
+				table_destroy(2, user, sd.speed_coefficient)
 				return
 		else
-			table_destroy(2, user)
+			table_destroy(2, user, sd.speed_coefficient)
 			return
 
 	if (istype(I, /obj/item/weapon/tool/wrench))
+		var/obj/item/weapon/tool/wrench/wrench = I
 		if(istype(src, /obj/structure/table/reinforced))
 			var/obj/structure/table/reinforced/RT = src
 			if(RT.status == 1)
-				table_destroy(3, user)
+				table_destroy(3, user, wrench.speed_coefficient)
 				return
 		else
-			table_destroy(3, user)
+			table_destroy(3, user, wrench.speed_coefficient)
 			return
 
 	if (istype(I, /obj/item/weapon/storage/bag/tray))
@@ -193,7 +195,7 @@
 #define TBL_DISASSEMBLE 2
 #define TBL_DECONSTRUCT 3
 
-/obj/structure/table/proc/table_destroy(destroy_type, mob/user)
+/obj/structure/table/proc/table_destroy(destroy_type, mob/user, speed_coefficient = 1)
 
 	if(destroy_type == TBL_DESTROY)
 		for(var/i = 1, i <= framestackamount, i++)
@@ -206,7 +208,7 @@
 	if(destroy_type == TBL_DISASSEMBLE)
 		user << "<span class='notice'>You start disassembling [src]...</span>"
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		if(do_after(user, 20, target = src))
+		if(do_after(user, 20 * speed_coefficient, target = src))
 			new frame(src.loc)
 			for(var/i = 1, i <= buildstackamount, i++)
 				new buildstack(get_turf(src))
@@ -216,7 +218,7 @@
 	if(destroy_type == TBL_DECONSTRUCT)
 		user << "<span class='notice'>You start deconstructing [src]...</span>"
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 40, target = src))
+		if(do_after(user, 40 * speed_coefficient, target = src))
 			for(var/i = 1, i <= framestackamount, i++)
 				new framestack(get_turf(src))
 			for(var/i = 1, i <= buildstackamount, i++)


### PR DESCRIPTION
Fixes #1193
### Intent of your Pull Request

Requested by Adam, increases the speed of the tools in the syndicate toolbox by 30%. Other than by their speed, they cannot be differentiated from normal except that the crowbar, wirecutters, and screwdriver are always red, as was the case previously.

Also fixed a bug where tables were not respecting the speed_coefficient var of the tool, and changed the toolbox description in the syndicate uplink to be accurate. It previously stated that the kit came with wires but not insulated gloves, when in fact it always came with insulated gloves and not wires.
#### Changelog

:cl:
rscadd: The tools in the syndicate toolbox now work 30% faster than normal tools in all timed operations.
/:cl:
