### PR TITLE
Makes the 'Gar' mode on chameleon thermals the black gar glasses

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -287,7 +287,7 @@
 				icon_state = "welding-g"
 				item_state = "welding-g"
 			if("Gar")
-				desc = "Just who the hell do you think I am?!"
-				name = "gar glasses"
-				icon_state = "gar"
-				item_state = "gar"
+				desc = "Go beyond impossible and kick reason to the curb!"
+				name = "black gar glasses"
+				icon_state = "garb"
+				item_state = "garb"


### PR DESCRIPTION
### Intent of your Pull Request

Basically, the current gar sprite is either not possible to get in game or very hard to find. The black gar glasses are readily available if you know where they are, and they look really nice on your character. (Disclaimer: this doesn't make them embed)
#### Changelog

:cl: ShadowDeath6
tweak: The Gar function on the Chameleon Thermals now disguises them as black gars.
/:cl:
