### PR TITLE
Fixes light bulbs not updating the lighting

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -278,20 +278,19 @@
 
 	update_icon()
 	if(on)
-		if(!light || light.radius != brightness)
-			switchcount++
-			if(rigged)
-				if(status == LIGHT_OK && trigger)
-					explode()
-			else if( prob( min(60, switchcount*switchcount*0.01) ) )
-				if(status == LIGHT_OK && trigger)
-					status = LIGHT_BURNED
-					icon_state = "[base_state]-burned"
-					on = 0
-					SetLuminosity(0)
-			else
-				use_power = 2
-				SetLuminosity(brightness)
+		switchcount++
+		if(rigged)
+			if(status == LIGHT_OK && trigger)
+				explode()
+		else if( prob( min(60, switchcount*switchcount*0.01) ) )
+			if(status == LIGHT_OK && trigger)
+				status = LIGHT_BURNED
+				icon_state = "[base_state]-burned"
+				on = 0
+				SetLuminosity(0)
+		else
+			use_power = 2
+			SetLuminosity(brightness)
 	else
 		use_power = 1
 		SetLuminosity(0)


### PR DESCRIPTION
Refer to issues #883 , #910 , #1198 .
### Intent of your Pull Request

Light bulbs now properly update lighting.
**Cause of issue:** When lightbulb is removed from fixture, the "light" (light datum) datum's variable radius is set to 4 in SetLuminosity (since that's the LIGHTING_MIN_RADIUS)

```
radius = max(LIGHTING_MIN_RADIUS, new_luminosity)
```

and since the brightness of the light bulb fixture is 4, it doesn't pass the `light.radius != brightness` part of 

```
if(!light || light.radius != brightness)
```

In fact, I'm not sure what this check is set to accomplish, exactly, as update() is only called when you do something to the light fixture (turn it on/off, take out/put in lightbulb) therefore I just removed the check entirely, as there's no reason for this check to be done, really (!light part is covered in SetLuminosity proc already and I have no idea why you need the `light.radius != brightness` check since both of those are hardcoded values (sort of)).
#### Changelog

:cl: X-TheDark
bugfix: Light bulb fixtures now properly update the surrounding tile brightness when their state is changed (put in lightbulb/turn fixture on).
/:cl:
