### PR TITLE
Cult Changes- Manifest

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -33,3 +33,20 @@
 	density = 1
 	unacidable = 1
 	anchored = 1.0
+
+/obj/structure/barricade/cult
+	name = "ethereal field"
+	desc = "Strange energies float around this, although it looks easy enough to break."
+	icon = 'icons/obj/cult.dmi'
+	icon_state = "cultgirder"
+	anchored = 1.0
+	density = 1.0
+	var/health = 1.0
+	var/maxhealth = 1.0
+	alpha = 100
+
+/obj/structure/barricade/cult/attackby(obj/item/W, mob/user, params)
+	src.health -= W.force
+	if (src.health <= 0)
+		visible_message("<span class='warning'>[src] vanishes in a puff of smoke.</span>")
+		qdel(src)

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -360,11 +360,13 @@ var/list/sacrificed = list()
 		usr.visible_message("<span class='danger'>[usr]'s eyes glow blue as \he freezes in place, absolutely motionless.</span>", \
 		"<span class='danger'>The shadow that is your spirit separates itself from your body. You are now in the realm beyond. While this is a great sight, being here strains your mind and body. Hurry...</span>", \
 		"<span class='italics'>You hear only complete silence for a moment.</span>")
+		var/obj/structure/barricade/cult/B = new(src.loc)
 		usr.ghostize(1)
 		L.ajourn = 1
 		while(L)
 			if(L.key)
 				L.ajourn=0
+				qdel(B)
 				return
 			else
 				L.take_organ_damage(10, 0)
@@ -390,7 +392,8 @@ var/list/sacrificed = list()
 		return this_rune.fizzle()
 
 	usr.say("Gal'h'rfikk harfrandid mud[pick("'","`")]gib!")
-	var/mob/living/carbon/human/dummy/D = new(this_rune.loc)
+	var/mob/living/carbon/human/D = new(this_rune.loc)
+	var/obj/structure/barricade/cult/B = new(this_rune.loc)
 	usr.visible_message("<span class='danger'>A shape forms in the center of the rune. A shape of... a man.</span>", \
 	"<span class='danger'>A shape forms in the center of the rune. A shape of... a man.</span>", \
 	"<span class='italics'>You hear liquid flowing.</span>")
@@ -415,8 +418,10 @@ var/list/sacrificed = list()
 	if(D)
 		D.visible_message("<span class='danger'>[D] slowly dissipates into dust and bones.</span>", \
 		"<span class='danger'>You feel pain, as bonds formed between your soul and this homunculus break.</span>", \
-		"<span class='italics'>You hear faint rustle.</span>")
+		"<span class='italics'>You hear a faint rustle.</span>")
 		D.dust()
+	if(B)
+		qdel(B)
 	return
 
 


### PR DESCRIPTION
Refer to issue #1083 .
### Intent of your Pull Request

Makes humans created by manifest actual humans instead of dummies, letting you soulstone them correctly. If a cultist has a soulstone and takes the time to make the rune and get a ghost, they deserve it, right?

tl;dr shadow likes buffing construct cult

Also spawns an 'ethereal field' on top of a cultist when they use astral journey or manifest, can be broken with anything that does more than 0 damage

I tried to make manifest alert ghosts upon writing but I'm not sure how to do that so if someone could inform me that would be appreciated
#### Changelog

:cl: ShadowDeath6
rscadd: Astral Journey and Manifest runes create an Ethereal Field on top of the caster, preventing them from being pushed around. They can be broken with anything that does damage.
tweak: Manifested ghosts can now be soulstoned while unconscious or dead.
/:cl:
