### PR TITLE
Fixes abductors

### DIFF
--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -240,7 +240,6 @@
 		V.flags |= NODROP
 	agent.equip_to_slot_or_del(V, slot_wear_suit)
 	agent.equip_to_slot_or_del(new /obj/item/weapon/abductor_baton(agent), slot_in_backpack)
-	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/alien(agent), slot_belt)
 	agent.equip_to_slot_or_del(new /obj/item/device/abductor/silencer(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/abductor(agent), slot_head)
 

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -823,7 +823,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	say_mod = "gibbers"
 	sexes = 0
 	invis_sight = SEE_INVISIBLE_LEVEL_ONE
-	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE)
+	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE,NOGUNS)
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/agent = 0
 	var/team = 1

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -823,10 +823,18 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	say_mod = "gibbers"
 	sexes = 0
 	invis_sight = SEE_INVISIBLE_LEVEL_ONE
-	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE,NOGUNS)  //Their hands don't have fingers, so no pulling triggers.
+	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE)
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/agent = 0
 	var/team = 1
+
+/datum/species/abductor/handle_vision(mob/living/carbon/human/H)
+	//custom override because darksight APPARENTLY DOESN"T WORK LIKE THIS BY DEFAULT??
+	..()
+	H.sight |= SEE_MOBS
+	H.permanent_sight_flags |= SEE_MOBS
+	H.see_in_dark = 8
+	invis_sight = SEE_INVISIBLE_MINIMUM
 
 /datum/species/abductor/handle_speech(message)
 	//Hacks

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -823,7 +823,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	say_mod = "gibbers"
 	sexes = 0
 	invis_sight = SEE_INVISIBLE_LEVEL_ONE
-	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE)
+	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE,NOGUNS)  //Their hands don't have fingers, so no pulling triggers.
 	var/scientist = 0 // vars to not pollute spieces list with castes
 	var/agent = 0
 	var/team = 1


### PR DESCRIPTION
Refer to literally any abductor round.
### Intent of Pull Request

-Adds NOGUNS to abductor.
Yeah, it stretches MUH IMMERSIONS a little bit, but right now abductors have no need for their fancy batons since they can port into the armory at roundstart and load up on ranged stuns.
#### Changelog

:cl:
tweak: While studying an abductor corpse, centcom scientists came to the realization that abductors don't actually have fingers.  Since this revelation, abductors all over the galaxy have returned to using their batons and no longer seem to be capable of operating guns.
/:cl:

high-effort out of 5
