### PR TITLE
Fixed fireball not working when critted while holding it

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -170,15 +170,16 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 
 /obj/effect/proc_holder/spell/proc/perform(list/targets, recharge = 1, mob/user = usr) //if recharge is started is important for the trigger spells
 	before_cast(targets)
-	invocation()
-	user.attack_log += text("\[[time_stamp()]\] <span class='danger'>[user.real_name] ([user.ckey]) cast the spell [name].</span>")
+	if(user)
+		user.attack_log += text("\[[time_stamp()]\] <span class='danger'>[user.real_name] ([user.ckey]) cast the spell [name].</span>")
+		invocation(user)
 	spawn(0)
 		if(charge_type == "recharge" && recharge)
 			start_recharge()
 	if(prob(critfailchance))
 		critfail(targets)
 	else
-		cast(targets)
+		cast(targets, user)
 	after_cast(targets)
 
 /obj/effect/proc_holder/spell/proc/before_cast(list/targets)
@@ -225,7 +226,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 				smoke.start()
 
 
-/obj/effect/proc_holder/spell/proc/cast(list/targets)
+/obj/effect/proc_holder/spell/proc/cast(list/targets, mob/user)
 	return
 
 /obj/effect/proc_holder/spell/proc/critfail(list/targets)

--- a/code/datums/spells/thrown.dm
+++ b/code/datums/spells/thrown.dm
@@ -9,7 +9,7 @@
 	var/held_icon_state = "2"
 	var/speed = 2
 
-/obj/effect/proc_holder/spell/thrown/proc/post_summon_holder(var/obj/item/cast_holder/CH)
+/obj/effect/proc_holder/spell/thrown/proc/post_summon_holder(obj/item/cast_holder/CH)
 	return
 
 /obj/effect/proc_holder/spell/thrown/choose_targets()
@@ -39,9 +39,9 @@
 	var/obj/effect/proc_holder/spell/thrown/spell = null
 	var/cast = 0
 
-/obj/item/cast_holder/dropped()
+/obj/item/cast_holder/dropped(mob/usermob)
 	if(!cast)
-		spell.perform(list(get_turf(src))) // You tried to drop the spell, it detonates on you. Bitch.
+		spell.perform(list(get_turf(src)), user = usermob) // You tried to drop the spell, it detonates on you. Bitch.
 		cast = 1
 	qdel(src)
 	return
@@ -77,13 +77,13 @@
 	held_icon = 'icons/effects/fire.dmi'
 	held_icon_state = "fire"
 
-/obj/effect/proc_holder/spell/thrown/fireball/cast(list/targets)
+/obj/effect/proc_holder/spell/thrown/fireball/cast(list/targets, mob/user)
 	for(var/atom/target in targets)
 		var/turf/T = get_turf(target)
-		var/obj/effect/fire_ball/F = new(get_turf(usr))
+		var/obj/effect/fire_ball/F = new(get_turf(user))
 		F.cast_at(T)
 
-/obj/effect/proc_holder/spell/thrown/fireball/post_summon_holder(var/obj/item/cast_holder/CH)
+/obj/effect/proc_holder/spell/thrown/fireball/post_summon_holder(obj/item/cast_holder/CH)
 	CH.force = 15
 	CH.damtype = "fire"
 


### PR DESCRIPTION
Refer to issue #1219 .
### Intent of your Pull Request

One of the most peculiar and interesting bugs I had to fix.

**Cause:** Basically, if we dropped the fireball due to crit-damage, **somewhere down the proc call stack _usr_ (BYOND built-in var) started returning null**, which caused line 83 `var/obj/effect/fire_ball/F = new(get_turf(usr)) (before fix)` to create the fireball (the thing that gets created when you drop/throw the thing you hold in hand) in null-space, fucking everything up. This also applied to invocation(), that also needed to have user passed explicitly, rather than using usr.

One of the best showcases of the big bold text from http://www.byond.com/docs/ref/info.html#/proc/var/usr

**Fix:** Explicitly pass the user to the proc, instead of using usr inside it. Fixes both fireball not triggering and it not being able to recharge ever.
#### Changelog

:cl: X-TheDark
bugfix: Fireball now correctly triggers when the holder drops it due to crit-damage.
/:cl:
