### PR TITLE
Nerfs revolver damage to 35

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/a357
 	desc = "A .357 bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/heavybullet
 
 /obj/item/ammo_casing/a50
 	desc = "A .50AE bullet casing."


### PR DESCRIPTION
Refer to issue #1226.
### Intent of your Pull Request

Basically, the intent is so you cannot kill as many people with the revolver with 1 clip.

Changes the ammo type of the revolver cylinder to heavybullet, that does 35 damage.
So now, instead of being able to crit people in 2 shots, you need 3 (for unarmoured people).

Boolet points:
- Shooting HoS in the chest with this 4 times will deal 98 damage.
- Total damage went down from 420 to 245
- Crits in 3 instead of 2
#### Changelog

:cl: X-TheDark
rscadd: Revolver does 35 damage per shot instead of 60.
/:cl:
