### PR TITLE
Fixes ID being deleted when deconstructing ore redemption machine

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -50,6 +50,9 @@ var/time_last_changed_position = 0
 	if(scan)
 		scan.loc = loc
 		scan = null
+	if(modify)
+		modify.loc = loc
+		modify = null
 	..()
 
 /obj/machinery/computer/card/attackby(obj/O, mob/user, params)//TODO:SANITY
@@ -482,6 +485,17 @@ var/time_last_changed_position = 0
 		modify.update_label()
 	updateUsrDialog()
 	return
+
+/obj/machinery/computer/card/power_change()
+	..()
+	if((stat & NOPOWER) && (scan || modify))
+		loc.visible_message("<span class='notice'>\The [src] ejects [scan ? (modify ? "[scan] and [modify]" : "[scan]") : "[modify]"] due to power failure.</span>")
+		if(scan)
+			scan.forceMove(loc)
+			scan = null
+		if(modify)
+			modify.forceMove(loc)
+			modify = null
 
 /obj/machinery/computer/card/proc/get_subordinates(rank)
 	for(var/datum/job/job in SSjob.occupations)

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -76,6 +76,13 @@
 		return attack_hand(user)
 	..()
 
+/obj/machinery/computer/prisoner/power_change()
+	..()
+	if((stat & NOPOWER) && inserted_id)
+		loc.visible_message("<span class='notice'>\The [src] ejects \The [inserted_id] due to power failure.</span>")
+		inserted_id.forceMove(loc)
+		inserted_id = null
+
 /obj/machinery/computer/prisoner/process()
 	if(!..())
 		src.updateDialog()

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -108,7 +108,7 @@
 		return
 	if(panel_open)
 		if(istype(W, /obj/item/weapon/tool/crowbar))
-			empty_content()
+			empty_content("deconstruct")
 			default_deconstruction_crowbar(W)
 		return 1
 	..()
@@ -258,6 +258,9 @@
 			new s.type(unloadloc, num_to_unload)
 			s.use(num_to_unload)
 		stack_list -= s.type
+
+	if(mode == "deconstruct" && inserted_id)
+		inserted_id.forceMove(unloadloc)
 
 /**********************Mining Equipment Vendor**************************/
 

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -126,6 +126,13 @@
 		return
 	interact(user)
 
+/obj/machinery/mineral/ore_redemption/power_change()
+	..()
+	if((stat & NOPOWER) && inserted_id)
+		loc.visible_message("<span class='notice'>\The [src] ejects \The [inserted_id] due to power failure.</span>")
+		inserted_id.forceMove(loc)
+		inserted_id = null
+
 /obj/machinery/mineral/ore_redemption/interact(mob/user)
 	var/obj/item/stack/sheet/s
 	var/dat
@@ -261,6 +268,7 @@
 
 	if(mode == "deconstruct" && inserted_id)
 		inserted_id.forceMove(unloadloc)
+		inserted_id = null
 
 /**********************Mining Equipment Vendor**************************/
 

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -68,6 +68,12 @@
 		emagged = 1
 		user << "<span class='warning'>PZZTTPFFFT</span>"
 
+/obj/machinery/mineral/labor_claim_console/power_change()
+	..()
+	if((stat & NOPOWER) && inserted_id)
+		loc.visible_message("<span class='notice'>\The [src] ejects \The [inserted_id] due to power failure.</span>")
+		inserted_id.forceMove(loc)
+		inserted_id = null
 
 
 /obj/machinery/mineral/labor_claim_console/Topic(href, href_list)


### PR DESCRIPTION
Refer to issue #28 (sort of).
### Intent of your Pull Request

If machine has ID in it, it is ejected when the machine is deconstructed, instead of being deleted.
#### Changelog

:cl: X-TheDark
rscadd: Ore Redemption Machine no longer eats your inserted ID permanently if it is deconstructed.
rscadd: Machines that accept your ID will now eject them if they become unpowered. If you still encounter any machines that do not do this, please point fingers at me and laugh (and make a GitHub issue).
/:cl:
