### PR TITLE
Items dropped by burned storages now don't take up entire tile

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -191,6 +191,12 @@
 				cy--
 	closer.screen_loc = "[4+cols+1]:16,2:16"
 
+/obj/item/weapon/storage/burn()
+	for(var/obj/item/Item in contents)
+		remove_from_storage(Item, get_turf(src))
+		Item.fire_act() //Set them on fire, too
+	..()
+
 
 /datum/numbered_display
 	var/obj/item/sample_object

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -191,12 +191,6 @@
 				cy--
 	closer.screen_loc = "[4+cols+1]:16,2:16"
 
-/obj/item/weapon/storage/burn()
-	for(var/obj/item/Item in contents)
-		remove_from_storage(Item, get_turf(src))
-		Item.fire_act() //Set them on fire, too
-	..()
-
 
 /datum/numbered_display
 	var/obj/item/sample_object

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -176,9 +176,6 @@
 		return 1
 
 /obj/proc/burn()
-	for(var/obj/item/Item in contents) //Empty out the contents
-		Item.loc = src.loc
-		Item.fire_act() //Set them on fire, too
 	var/obj/effect/decal/cleanable/ash/A = new(src.loc)
 	A.desc = "Looks like this used to be a [name] some time ago."
 	SSobj.burning -= src

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -176,6 +176,11 @@
 		return 1
 
 /obj/proc/burn()
+	for(var/obj/item/Item in contents)
+		Item.loc = src.loc
+		Item.layer = initial(Item.layer)
+		Item.mouse_opacity = initial(Item.mouse_opacity)
+		Item.fire_act() //Set them on fire, too
 	var/obj/effect/decal/cleanable/ash/A = new(src.loc)
 	A.desc = "Looks like this used to be a [name] some time ago."
 	SSobj.burning -= src


### PR DESCRIPTION
Refer to issue #368 .
### Intent of your Pull Request

~~Moved the burn() code that empties the contents to the storage objects.~~

Storage objects now properly update their icons so they don't take the entire tile up for clicking purposes.
#### Changelog

Don't think it's needed.
