### PR TITLE
Fixes infinite taser

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -72,10 +72,8 @@
 	fire_sound = shot.fire_sound
 	fire_delay = shot.delay
 	if(chambered)
-		var/obj/item/ammo_casing/energy/chambered_energy = chambered
-		if(istype(chambered_energy))
-			power_supply.give(chambered_energy.e_cost)//refund!
-	process_chamber()
+		chambered = null
+		newshot()
 	if (shot.select_name)
 		user << "<span class='notice'>[src] is now set to [shot.select_name].</span>"
 	update_icon()


### PR DESCRIPTION
Refer to issue #1231.
### Intent of your Pull Request

Fixes your taser shot being refunded if you have it chambered.

Basically, **blame me**. Due to the wonky-spaghetti way I handle the cyborg LMG (mostly the **`after_attack()` and `process_chamber()` code** I modified to make burst firing energy weapons), this very unintuitive thing happens.

**Cause:** For burst firing we need to have a round chambered, but the **energy cost is only deducted after actually firing (in `process_chamber()`)**, which means that **if you have a round chambered, refunding it gives you energy for free**, since **chambering a round doesn't cost any energy**, firing it does. In addition if you have enough for disabler but not electrode ammo, you can fire disabler, switch types and still have the disabler beam chambered (because it doesn't remove the old one due to not enough energy for electrode), so I also needed to unchamber the chambered round...all of this because of me adding burst fire capability to Cyborg LMG...

**Fix:** Unchamber the round and don't refund the cost, because it's deducted after firing, not chambering. Also prevents firing after switching mode if you don't have enough energy for the new selected ammo type (so it uses the one it chambered after shooting the previous mode).
#### Changelog

:cl: X-TheDark
rscadd: Taser no longer can have infinite energy.
/:cl:
