### PR TITLE
fixes sec wanted icons not behaving how they should with face coverings.

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -155,16 +155,18 @@
 				holder.icon_state = "hud_imp_chem"
 
 /mob/living/carbon/human/proc/sec_hud_set_security_status()
-	var/image/holder
+	var/image/holder = hud_list[WANTED_HUD]
 	var/perpname = get_face_name(get_id_name(""))
 	if(perpname)
 		var/datum/data/record/R = find_record("name", perpname, data_core.security)
 		if(R)
-			holder = hud_list[WANTED_HUD]
 			switch(R.fields["criminal"])
 				if("*Arrest*")		holder.icon_state = "hudwanted"
 				if("Incarcerated")	holder.icon_state = "hudincarcerated"
 				if("Parolled")		holder.icon_state = "hudparolled"
 				if("Discharged")	holder.icon_state = "huddischarged"
 				else				holder.icon_state = null
-
+		else
+			holder.icon_state = null
+	else
+		holder.icon_state = null

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -52,6 +52,7 @@
 		handle_embedded_objects()
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
+	sec_hud_set_security_status()
 
 	if(dna)
 		dna.species.spec_life(src) // for mutantraces


### PR DESCRIPTION
### Intent of your Pull Request

Fixes some bugs with how the security hud wanted icon played with face coverings.
#### Changelog

:cl:
bugfix: Changing someone's wanted status will now update the sechud icon even if their face is covered at the time.
bugfix: Covering your face and hiding your ID while wanted will now properly hide the sechud wanted icon.
/:cl:
