### PR TITLE
Security Updates (INCLUDES SECHUD HOTKEYS)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -359,3 +359,113 @@
 		var/turf/T = screen_loc2turf(modifiers["screen-loc"], get_turf(usr))
 		T.Click(location, control, params)
 	return 1
+
+///////////////////////////////////////
+///////////// HUD HOTKEYS /////////////
+///////////////////////////////////////
+
+/mob/living/carbon/human/ShiftAltClickOn(atom/A)
+	if(istype(A, /mob/living/carbon/human))
+		if(A == src)
+			return
+
+		var/obj/item/organ/internal/cyberimp/eyes/hud/CIH = src.getorgan(/obj/item/organ/internal/cyberimp/eyes/hud)
+		if(istype(src.glasses, /obj/item/clothing/glasses/hud/security) || istype(CIH,/obj/item/organ/internal/cyberimp/eyes/hud/security))
+			var/allowed_access = checkHUDaccess(sec=1)
+			if(!allowed_access) return
+			var/mob/living/carbon/human/AH = A
+			var/perpname = AH.get_face_name(get_id_name(""))
+			var/datum/data/record/R = find_record("name", perpname, data_core.general)
+			R = find_record("name", perpname, data_core.security)
+			if(R)
+				var/setcriminal = input(usr, "Specify a new criminal status for this person.", "Security HUD", R.fields["criminal"]) in list("None", "*Arrest*", "Incarcerated", "Parolled", "Discharged", "Cancel")
+				if(setcriminal != "Cancel")
+					if(src.canUseHUD())
+						if(src in view(10, AH))
+							investigate_log("[AH.key] has been set from [R.fields["criminal"]] to [setcriminal] by [src.name] ([src.key]).", "records")
+							R.fields["criminal"] = setcriminal
+							AH.sec_hud_set_security_status()
+							return
+						src << "<span class='alert'>The target is out of range!</span>"
+
+/mob/living/carbon/human/CtrlShiftClickOn(atom/A)
+	if(istype(A, /mob/living/carbon/human))
+		if(A == src)
+			return
+
+		var/mob/living/carbon/human/AH = A
+		var/perpname = AH.get_face_name(get_id_name(""))
+		var/datum/data/record/R = find_record("name", perpname, data_core.security)
+		var/allowed_access1 = checkHUDaccess(sec=1)
+//		var/allowed_access2 = checkHUDaccess(med=1)
+
+		var/obj/item/organ/internal/cyberimp/eyes/hud/CIH = src.getorgan(/obj/item/organ/internal/cyberimp/eyes/hud)
+		if(istype(src.glasses, /obj/item/clothing/glasses/hud/security) || istype(CIH,/obj/item/organ/internal/cyberimp/eyes/hud/security))
+			if(!allowed_access1) return
+			switch(alert("What would you like to add?","Security HUD","Minor Crime","Major Crime", "Comment", "Cancel"))
+				if("Minor Crime")
+					if(R)
+						var/t1 = stripped_input("Please input minor crime names:", "Security HUD", "", null)
+						var/t2 = stripped_multiline_input("Please input minor crime details:", "Security HUD", "", null)
+						if(R)
+							if (!t1 || !t2 || !allowed_access1) return
+							else if(!src.canUseHUD()) return
+							var/crime = data_core.createCrimeEntry(t1, t2, allowed_access1, worldtime2text())
+							data_core.addMinorCrime(R.fields["id"], crime)
+							src << "<span class='notice'>Successfully added a minor crime.</span>"
+							return
+				if("Major Crime")
+					if(R)
+						if(!allowed_access1) return
+						var/t1 = stripped_input("Please input major crime names:", "Security HUD", "", null)
+						var/t2 = stripped_multiline_input("Please input major crime details:", "Security HUD", "", null)
+						if(R)
+							if (!t1 || !t2 || !allowed_access1) return
+							else if (!src.canUseHUD()) return
+							var/crime = data_core.createCrimeEntry(t1, t2, allowed_access1, worldtime2text())
+							data_core.addMajorCrime(R.fields["id"], crime)
+							src << "<span class='notice'>Successfully added a major crime.</span>"
+				if("Comment")
+					if(R)
+						var/t1 = stripped_multiline_input("Add Comment:", "Secure. records", null, null)
+						if(R)
+							if (!t1 || !allowed_access1) return
+							else if(!src.canUseHUD()) return
+							var/counter = 1
+							while(R.fields[text("com_[]", counter)])
+								counter++
+							R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access1, worldtime2text(), time2text(world.realtime, "MMM DD"), year_integer+540, t1,)
+							src << "<span class='notice'>Successfully added comment.</span>"
+
+/*			FUTURE USE POSSIBLY??
+		if(istype(src.glasses, /obj/item/clothing/glasses/hud/health) || istype(CIH,/obj/item/organ/internal/cyberimp/eyes/hud/medical))
+			if(!allowed_access2) return
+*/
+
+
+/mob/living/carbon/human/proc/checkHUDaccess(var/sec = 0, var/med = 0)
+	if(!sec && !med)
+		message_admins("Yell at Super3222, something went wrong with the proc call checkHUDaccess()")
+		return
+	var/allowed_id = null
+	var/obj/item/clothing/glasses/G = src.glasses
+	if (!G.emagged)
+		if(src.wear_id)
+			var/list/access = src.wear_id.GetAccess()
+			if(sec)
+				if(access_brig in access)
+					allowed_id = src.get_authentification_name()
+					return allowed_id
+			if(med)
+				if(access_brig in access)
+					allowed_id = src.get_authentification_name()
+					return allowed_id
+		else
+			return 0
+	else
+		allowed_id = "@%&ERROR_%$*"
+		return allowed_id
+
+	if(!allowed_id)
+		src << "<span class='warning'>ERROR: Invalid Access</span>"
+		return 0

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -145,13 +145,15 @@ for reference:
 	var/obj/item/device/encryptionkey/installedkey = null
 	var/radio_freq
 	var/initialdesc
+	var/healthreport
+	var/round_start_intialize = 0 // 0 for didn't happen, one for did.
 
 	// Security Barrier Modifications
 	var/obj/item/device/assembly/signaler/SIGNALLER = null
 	var/obj/item/device/assembly/prox_sensor/PROXY = null
 	var/obj/item/weapon/card/id/ID_CARD = null
 	var/obj/item/device/assembly/infra/INFRA = null
-	var/obj/item/assembly/shock_kit/SHOCK = null
+	var/obj/item/assembly/shock_kit/SHOCKING = null
 
 //	req_access = list(access_maint_tunnels)
 
@@ -161,17 +163,27 @@ for reference:
 	src.icon_state = "barrier[src.locked]"
 	attachedradio = new /obj/item/device/radio(src)
 	attachedradio.listening = 0
-	attachedradio.frequency = 1359
 	initialdesc = desc
-
-	radio_freq = SEC_FREQ
 	installedkey = new /obj/item/device/encryptionkey/headset_sec
+
+/obj/machinery/deployable/barrier/process()
+	if(ticker && ticker.current_state == GAME_STATE_PREGAME)
+		return
+	if(!round_start_intialize)
+		setup_round_start_intialize()
+	return
+
+/obj/machinery/deployable/barrier/proc/setup_round_start_intialize()
+	if(ticker && ticker.current_state > GAME_STATE_PREGAME)
+		attachedradio.set_frequency(SEC_FREQ)
+		radio_freq = SEC_FREQ
+		round_start_intialize = 1
 
 /obj/machinery/deployable/barrier/attackby(obj/item/weapon/W, mob/user, params)
 	if (W.GetID())
 		if (src.allowed(user))
 			if	(src.emagged < 2.0)
-				switch(alert("Selection Prompt","Barrier Uplink", "Lock","Rename", "Cancel"))
+				switch(alert("Selection Prompt","Barrier Uplink", "Lock","Rename", "Toggle Functionality Report","Cancel"))
 					if("Lock")
 						src.locked = !src.locked
 						src.anchored = !src.anchored
@@ -187,16 +199,20 @@ for reference:
 						if(!in_range(src, usr) && src.loc != usr)
 							return
 						if(new_name)
+							message_admins("[user] is changing [name] to [new_name]. ([loc.x],[loc.y],[loc.z]) <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>(JMP)")
+							log_game("[user] has changed [name] to [new_name].")
 							var/randomdigit = "([rand(50,1000)])"
 							name = new_name
 							name += " - Barrier [randomdigit]"
-							message_admins("[user] is changing [name] to [new_name]. ([loc.x],[loc.y],[loc.z]) <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>(JMP)")
-							log_game("[user] has changed [name] to [new_name].")
 						else
 							return
-
-					if("Cancel")
-						return
+					if("Toggle Functionality Report")
+						if(healthreport)
+							healthreport = !healthreport
+							user << "<span class='notice'>You toggle off the barrier's functionality report. It will no longer report how much health it is has remaining.</span>"
+						else
+							healthreport = 1
+							user << "<span class='notice'>You toggle on the barrier's functionality report. It will now report how much health it is has remaining.</span>"
 			else
 				var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 				s.set_up(2, 1, src)
@@ -271,7 +287,7 @@ for reference:
 			W.loc = src
 			return
 
-/*		Is this even needed? Only the future can tell.
+/*		This isn't needed.
 		else if(installedkey.channels.Find("Syndicate"))
 			if(src.emagged < 1)
 				visible_message("[src] rejects the encryption key and vibrates aggressively!")
@@ -340,7 +356,7 @@ for reference:
 
 		// This will send a message to the security channel if the barrier's radio is connected to it's frequency
 
-		if (attachedradio.frequency == SEC_FREQ && !src.emagged) // security currently. emagging will disable this.
+		if (((attachedradio.frequency == SEC_FREQ || attachedradio.frequency == 1359)) && !src.emagged) // security currently. emagging will disable this.
 			if(!W.force)
 				return
 
@@ -352,23 +368,19 @@ for reference:
 
 			var/damagereport
 			if(W.force <= 5 && W.force != 0) // less or equal to 5
-				damagereport = "a small amount of damage."
+				damagereport = "a small amount of damage"
 			if(W.force > 5 && W.force <= 15) // in the 5-15 range, but greater than 5
-				damagereport = "a moderate amount of damage."
+				damagereport = "a moderate amount of damage"
 			if(W.force > 15) //greater than 15
-				damagereport = "a large amount of damage."
+				damagereport = "a large amount of damage"
 			else if (!damagereport)
 				return
 
-			if(src.health <= 95 && src.health > 50)
-				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] The barriers rate of functionality is at [health]%!!",radio_freq)
-
-			if(src.health <= 50 && src.health > 25)
-				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] The barriers rate of functionality is at [health]%!!",radio_freq)
-
-			if(src.health <= 25 && src.health > 0)
-				attachedradio.talk_into(src, "Alert! [thebarrier] is suffering [damagereport] The barriers rate of functionality is at [health]%!!",radio_freq)
-
+			if(src.health <= 95 && src.health > 50 || src.health <= 50 && src.health > 25 || src.health <= 25 && src.health > 0)
+				var/attack_report = "Alert! This barrier's systems are suffering [damagereport]"
+				if(healthreport)
+					attack_report += ". The barriers rate of functionality is at [health]%"
+				attachedradio.talk_into(src, "[attack_report]!!",radio_freq)
 
 /obj/machinery/deployable/barrier/proc/desc_report() // something to update the description of the barrier.
 
@@ -450,6 +462,6 @@ for reference:
 	s.start()
 
 	explosion(src.loc,-1,-1,0)
-	playsound(src.loc, 'sound/effects/Explosion1.ogg',75,1)
+	playsound(src.loc, 'sound/effects/Explosion1.ogg',100,1)
 	if(src)
 		qdel(src)

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -389,7 +389,7 @@ for reference:
 		return
 
 	if (src.health <= 60 && src.health >= 31)
-		desc = "[initialdesc] <span class='danger'>The barrier seems to have taken a multiude of strong blows.</span>"
+		desc = "[initialdesc] <span class='danger'>The barrier seems to have taken a multitude of strong blows.</span>"
 		return
 
 	if (src.health <= 30 && src.health > 1)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -60,6 +60,7 @@
 /obj/machinery/suit_storage_unit/security
 	SUIT_TYPE = /obj/item/clothing/suit/space/hardsuit/security
 	MASK_TYPE = /obj/item/clothing/mask/gas/sechailer
+	STORAGE_TYPE = /obj/item/clothing/shoes/magboots/security
 
 /obj/machinery/suit_storage_unit/hos
 	SUIT_TYPE = /obj/item/clothing/suit/space/hardsuit/security/hos

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -56,7 +56,7 @@
 
 /obj/item/clothing/shoes/magboots/security
 	name = "combat magboots"
-	desc = "Combat-edition magboots issued by Nanotrasen for security's extravehicular missions. Unlike the Syndicate, these do not carry such a burden on the wearer, however are still nothing to compare to the advanced version."
+	desc = "Combat-edition magboots issued by Nanotrasen Security for extravehicular missions. Unlike the Syndicates own, these do not carry such a heavy burden on the wearer, however are still nothing to compare to the advanced version."
 	icon_state = "cmagboots0"
-	magboot_state = "cmagboots0"
+	magboot_state = "cmagboots"
 	slowdown_active = 1

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -56,7 +56,7 @@
 
 /obj/item/clothing/shoes/magboots/security
 	name = "combat magboots"
-	desc = "Specialized combat-issued magboots crafted for tactical NT security missions while in the depth of space or when facing a vacuum. Though they are nothing compared to the advanced verson, they will make you more mobile than the standard edition. Has bright blue and white embroidered letters enscribed 'NT'  on the back of them."
+	desc = "Combat-edition magboots issued by Nanotrasen for security's extravehicular missions. Unlike the Syndicate, these do not carry such a burden on the wearer, however are still nothing to compare to the advanced version."
 	icon_state = "cmagboots0"
 	magboot_state = "cmagboots0"
 	slowdown_active = 1

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -114,7 +114,7 @@
 	name = "armor"
 	desc = "An armored vest with a detective's badge on it."
 	icon_state = "detective-armor"
-	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/device/flashlight,/obj/item/weapon/gun/energy,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter,/obj/item/device/detective_scanner,/obj/item/device/taperecorder)
+	allowed = list(/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/device/flashlight,/obj/item/weapon/gun/energy,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/classic_baton,/obj/item/weapon/restraints/handcuffs,/obj/item/weapon/storage/fancy/cigarettes,/obj/item/weapon/lighter,/obj/item/device/detective_scanner,/obj/item/device/taperecorder, /obj/item/weapon/melee/baton)
 	burn_state = 0 //Burnable
 
 


### PR DESCRIPTION
Refer to issue #209.
### Intent of your Pull Request

More security buff- I mean, updates.
- The police baton now fits inside of the detective's noir armor.
- Combat Magboots will now start inside of the Warden's suit storage's.
- When you use the barrier, a window will pop up with three options.
- Lock. This will lock / unlock the barrier.
- Rename. This will rename the barrier. It'll end up like this (name) - Barrier (random digit).
- Toggle Functionality Report. This will toggle whether the barriers will report how much health they have left. Good for reducing chat spam.
- Security Barriers will now start with already installed sec encryption keys. This will cover the ones that start in the armory as well as the ones that can be bought from Cargo. It's security.
- As Security, you can now use hotkeys to add crimes/comments or to set people's criminal status.
  CTRL + SHIFT = Adding minor/major crimes or comments.
  ALT + SHIFT = Setting peoples criminal status.
  It will require you to have security level ID.
#### Changelog

:cl:Super3222
rscadd: Security can now use HOTKEYS to operate criminal records! Requires you to be wearing a sec hud or have a cybernetic security implant installed.
tweak: ALT + SHIFT = Setting peoples criminal status
tweak: CTRL + SHIFT = Adding minor/major crimes or comments to peoples criminal record.
rscadd: Nanotrasen's Security has been granted more combat magboots! Check the Warden's suit storage for them.
rscadd: Deployable Barriers not only can be locked, but renamed, and give an option to toggle their functionality report.
rscadd: The Detective's armor now supports the storage of police batons.
/:cl:
