### PR TITLE
Makes the ticket counter visible to everyone at the end of the round.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -118,6 +118,7 @@ var/datum/subsystem/ticker/ticker
 
 			if(!mode.explosion_in_progress && mode.check_finished() || force_ending)
 				current_state = GAME_STATE_FINISHED
+				ticket_counter_visible_to_everyone = 1
 				toggle_ooc(1) // Turn it on
 				declare_completion(force_ending)
 				spawn(50)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -998,3 +998,7 @@ datum/admins/proc/cyberman_varedit(list/href_list)
 	var/message = "[key_name_admin(usr)] has toggled high risk item notifications [high_risk_item_notifications ? "on" : "off"]."
 	message_admins(message)
 	log_admin(message)
+
+/datum/admins/proc/toggle_ticket_counter_visibility()
+	ticket_counter_visible_to_everyone = !ticket_counter_visible_to_everyone
+	message_admins("[key_name_admin(usr)] has made the ticket counter [ticket_counter_visible_to_everyone ? "visible" : "invisible"] to normal players.")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -80,7 +80,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/reset_all_tcs,		/*resets all telecomms scripts*/
 	/datum/admins/proc/cybermen_panel,  //lots of cybermen options
 	/client/proc/toggle_restart_vote,	//moderator tool for toggling restart vote
-	/datum/admins/proc/toggle_high_risk_item_notifications //toggles notifying admins when objective items are destroyed or change z-levels
+	/datum/admins/proc/toggle_high_risk_item_notifications, //toggles notifying admins when objective items are destroyed or change z-levels
+	/datum/admins/proc/toggle_ticket_counter_visibility	//toggles all players being able to see tickets remaining
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -243,7 +244,8 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/admin_change_sec_level,
 	/client/proc/toggle_nuke,
 	/client/proc/cmd_display_del_log,
-	/datum/admins/proc/toggle_high_risk_item_notifications
+	/datum/admins/proc/toggle_high_risk_item_notifications,
+	/datum/admins/proc/toggle_ticket_counter_visibility
 	)
 
 /client/proc/add_admin_verbs()

--- a/code/modules/admin/tickets/admin_ticket.dm
+++ b/code/modules/admin/tickets/admin_ticket.dm
@@ -1,6 +1,7 @@
 
-/var/list/tickets_list = list()
-/var/ticket_count = 0;
+var/list/tickets_list = list()
+var/ticket_count = 0
+var/ticket_counter_visible_to_everyone = 0
 
 /datum/ticket_log
 	var/datum/admin_ticket/parent

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -699,7 +699,7 @@ var/list/slot_equipment_priority = list( \
 		stat(null, "Server Time: [time2text(world.realtime, "YYYY-MM-DD hh:mm")]")
 		stat(null, "Round: [yog_round_number]")
 
-		if(client && client.holder)
+		if(client && (client.holder || ticket_counter_visible_to_everyone))
 			var/tickets_unclaimed = 0
 			var/tickets_unresolved = 0
 			var/tickets_resolved = 0


### PR DESCRIPTION
Fixes #1234
### Intent of your Pull Request

Players can now see the number of tickets remaining after the round ends. There is also a new admin verb that allows admins to toggle this.
#### Changelog

:cl:
rscadd: Players can now see the number of tickets remaining when the round ends.
/:cl:
