### PR TITLE
Bomb implant buttons are useable in crit.

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -227,6 +227,9 @@
 /datum/action/item_action/hands_free
 	check_flags = AB_CHECK_ALIVE|AB_CHECK_INSIDE
 
+/datum/action/item_action/unrestricted
+	check_flags = AB_CHECK_INSIDE
+
 /datum/action/organ_action
 	check_flags = AB_CHECK_ALIVE
 

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -2,7 +2,7 @@
 	name = "implant"
 	icon = 'icons/obj/implants.dmi'
 	icon_state = "generic" //Shows up as the action button icon
-	action_button_is_hands_free = 1
+	action_button_is_hands_free = 1 //2 means you can use it while dead or in crit
 	origin_tech = "materials=2;biotech=3;programming=2"
 
 	var/activated = 1 //1 for implant types that can be activated, 0 for ones that are "always on" like loyalty implants

--- a/code/game/objects/items/weapons/implants/implant_explosive.dm
+++ b/code/game/objects/items/weapons/implants/implant_explosive.dm
@@ -3,6 +3,7 @@
 	desc = "And boom goes the weasel."
 	icon_state = "explosive"
 	origin_tech = "materials=2;combat=3;biotech=4;syndicate=4"
+	action_button_is_hands_free = 2
 	var/weak = 2
 	var/medium = 0.8
 	var/heavy = 0.4

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -145,6 +145,8 @@
 		if(!I.action)
 			if(istype(I, /obj/item/organ/internal))
 				I.action = new/datum/action/organ_action
+			else if(I.action_button_is_hands_free == 2)
+				I.action = new/datum/action/item_action/unrestricted
 			else if(I.action_button_is_hands_free)
 				I.action = new/datum/action/item_action/hands_free
 			else


### PR DESCRIPTION
Fixes #1217
### Intent of your Pull Request

You can now use the micro/macrobomb implant while in crit. Also while dead, if you somehow manage to be dead and not gibbed with a bomb implant inside you.
#### Changelog

:cl:
rscadd: You can now use the microbomb/macrobomb implant button while in crit. This still takes three seconds, so using *deathgasp or another form of succumbing is still faster.
/:cl:
