### PR TITLE
abductor agents now get an agent card.

### DIFF
--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -243,6 +243,7 @@
 	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/alien(agent), slot_belt)
 	agent.equip_to_slot_or_del(new /obj/item/device/abductor/silencer(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/abductor(agent), slot_head)
+	agent.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/abductor, slot_wear_id)
 
 
 /datum/game_mode/abduction/proc/equip_scientist(var/mob/living/carbon/human/scientist,var/team_number)

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -243,7 +243,7 @@
 	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/alien(agent), slot_belt)
 	agent.equip_to_slot_or_del(new /obj/item/device/abductor/silencer(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/abductor(agent), slot_head)
-	agent.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/abductor, slot_wear_id)
+	agent.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/abductor(agent), slot_wear_id)
 
 
 /datum/game_mode/abduction/proc/equip_scientist(var/mob/living/carbon/human/scientist,var/team_number)

--- a/code/game/gamemodes/abduction/machinery/console.dm
+++ b/code/game/gamemodes/abduction/machinery/console.dm
@@ -56,6 +56,7 @@
 		dat += "<a href='?src=\ref[src];dispense=helmet'>Agent Helmet</A><br>"
 		dat += "<a href='?src=\ref[src];dispense=silencer'>Radio Silencer</A><br>"
 		dat += "<a href='?src=\ref[src];dispense=tool'>Science Tool</A><br>"
+		dat += "<a href='?src=\ref[src];dispense=card'>Agent Card</A><br>"
 	else
 		dat += "<span class='bad'>NO EXPERIMENT MACHINE DETECTED</span> <br>"
 
@@ -116,6 +117,8 @@
 				Dispense(/obj/item/device/abductor/silencer)
 			if("tool")
 				Dispense(/obj/item/device/abductor/gizmo)
+			if("card")
+				Dispense(/obj/item/weapon/card/id/syndicate/abductor)
 	src.updateUsrDialog()
 
 /obj/machinery/abductor/console/proc/TeleporterSet()

--- a/code/game/gamemodes/abduction/traitor_abd.dm
+++ b/code/game/gamemodes/abduction/traitor_abd.dm
@@ -228,7 +228,7 @@
 	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/alien(agent), slot_belt)
 	agent.equip_to_slot_or_del(new /obj/item/device/abductor/silencer(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/abductor(agent), slot_head)
-	agent.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/abductor, slot_wear_id)
+	agent.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/abductor(agent), slot_wear_id)
 
 /datum/game_mode/traitor/abduction/proc/equip_scientist(var/mob/living/carbon/human/scientist,var/team_number)
 	if(!team_number)

--- a/code/game/gamemodes/abduction/traitor_abd.dm
+++ b/code/game/gamemodes/abduction/traitor_abd.dm
@@ -228,6 +228,7 @@
 	agent.equip_to_slot_or_del(new /obj/item/weapon/gun/energy/alien(agent), slot_belt)
 	agent.equip_to_slot_or_del(new /obj/item/device/abductor/silencer(agent), slot_in_backpack)
 	agent.equip_to_slot_or_del(new /obj/item/clothing/head/helmet/abductor(agent), slot_head)
+	agent.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/abductor, slot_wear_id)
 
 /datum/game_mode/traitor/abduction/proc/equip_scientist(var/mob/living/carbon/human/scientist,var/team_number)
 	if(!team_number)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -223,6 +223,12 @@ update_label("John Doe", "Clowny")
 	assignment = "Syndicate Overlord"
 	access = list(access_syndicate)
 
+/obj/item/weapon/card/id/syndicate/abductor
+	name = "abductor agent card"
+	desc = "A card that can copy access from the IDs of abductees."
+	access = list()
+	origin_tech = ""
+
 /obj/item/weapon/card/id/captains_spare
 	name = "captain's spare ID"
 	desc = "The spare ID of the High Lord himself."


### PR DESCRIPTION
Suggested in #1218
### Intent of your Pull Request

Abductors now get an agent card. They can also buy a new one for 1 data.
#### Changelog

:cl:
rscadd: Abductor agents now start with an agent card than can scan access from the cards of abductees. It starts with no access.
/:cl:
