### PR TITLE
Changes nukeops war to be a vote

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -119,8 +119,8 @@
 	synd_mind.current << "<B>If you feel you are not up to this task, give your ID to another operative.</B>"
 	synd_mind.current << "<B>In your hand you will find a special item capable of triggering a greater challenge for your team. Examine it carefully and consult with your fellow operatives before activating it.</B>"
 
-	var/obj/item/device/nuclear_challenge/challenge = new /obj/item/device/nuclear_challenge
-	synd_mind.current.equip_to_slot_or_del(challenge, slot_r_hand)
+	var/obj/item/device/nuclear_challenge/vote/voter = new /obj/item/device/nuclear_challenge/vote()
+	synd_mind.current.equip_to_slot_or_del(voter, slot_l_hand)
 
 	var/list/foundIDs = synd_mind.current.search_contents_for(/obj/item/weapon/card/id)
 	if(foundIDs.len)
@@ -179,6 +179,8 @@
 	if(synd_mob.backbag == 2) synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel_norm(synd_mob), slot_back)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/automatic/pistol(synd_mob), slot_belt)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(synd_mob.back), slot_in_backpack)
+	var/obj/item/device/nuclear_challenge/vote/voter = new /obj/item/device/nuclear_challenge/vote()
+	synd_mob.equip_to_slot_or_del(voter, slot_l_hand)
 
 	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(synd_mob)
 	U.hidden_uplink.uplink_owner="[synd_mob.key]"

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -13,20 +13,18 @@
 	var/used = 0
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
-	if(doChecks(user))
+	if(!doChecks(user))
+		return
+
+	var/are_you_sure = alert(user, "Are you sure you want to alert the enemy crew? You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for declaring War.", "Declare war?", "Yes", "No")
+
+	if(are_you_sure == "Yes")
+		if(!doChecks(user))
+			return
 		declare_nuclear_war(user)
 		used = 1
-
-/obj/item/device/nuclear_challenge/vote
-	name = "Declaration of War (Challenge Mode) Voter"
-	icon_state = "gangtool-yellow"
-	item_state = "walkietalkie"
-	desc = "Use to cast your vote for sending a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
-			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
-			Must be used within five minutes, or your benefactors will lose interest."
-	var/global/yesVotes = 0
-	var/global/noVotes = 0
-	var/global/votesNeeded = 3
+	else
+		user << "On second thought, the element of surprise isn't so bad after all."
 
 /obj/item/device/nuclear_challenge/proc/doChecks(mob/living/user)
 	if(loc != user)
@@ -48,6 +46,17 @@
 	return 1
 
 //The voting version
+
+/obj/item/device/nuclear_challenge/vote
+	name = "Declaration of War (Challenge Mode) Voter"
+	icon_state = "gangtool-yellow"
+	item_state = "walkietalkie"
+	desc = "Use to cast your vote for sending a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
+			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
+			Must be used within five minutes, or your benefactors will lose interest."
+	var/global/yesVotes = 0
+	var/global/noVotes = 0
+	var/global/votesNeeded = 3
 
 /obj/item/device/nuclear_challenge/vote/attack_self(mob/living/user)
 	if(!doChecks(user))

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -12,6 +12,56 @@
 			Must be used within five minutes, or your benefactors will lose interest."
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
+	declare_nuclear_war(user)
+
+/obj/item/device/nuclear_challenge/vote
+	name = "Declaration of War (Challenge Mode) Voter"
+	icon_state = "gangtool-yellow"
+	item_state = "walkietalkie"
+	desc = "Use to cast your vote for sending a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
+			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
+			Must be used within five minutes, or your benefactors will lose interest."
+	var/used = 0
+	var/global/yesVotes = 0
+	var/global/noVotes = 0
+	var/global/votesNeeded = 3
+
+/obj/item/device/nuclear_challenge/vote/attack_self(mob/living/user)
+	if(used)
+		user << "You have already voted."
+		return
+	used = 1
+	if(player_list.len < CHALLENGE_MIN_PLAYERS)
+		user << "The enemy crew is too small to be worth declaring war on."
+		return
+	if(user.z != ZLEVEL_CENTCOM)
+		user << "You have to be at your base to use this."
+		return
+
+	if(world.time > CHALLENGE_TIME_LIMIT)
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
+		return
+
+	if(yesVotes >= votesNeeded)
+		user << "Your vote no longer matters, your comrades have decided for you."
+		return
+	var/are_you_sure = alert(user, "Are you sure you want to vote to alert the enemy crew? You will receive [round(CHALLENGE_TC_PER_PLAYER*player_list.len)] bonus Telecrystals for declaring War. You cannot change your vote if you select Yes or No.", "Declare war?", "Yes", "No", "Cancel Vote")
+	if(are_you_sure == "Yes")
+		yesVotes++
+		announce("[usr.real_name] has voted YES for war. There are [yesVotes] for war and [noVotes] against war.")
+		if(yesVotes >= votesNeeded)
+			declare_nuclear_war(user)
+	else if(are_you_sure == "Yes")
+		noVotes++
+		announce("[usr.real_name] has voted NO for war. There are [yesVotes] for war and [noVotes] against war.")
+	else
+		user << "You decide to think it over more."
+
+/obj/item/device/nuclear_challenge/vote/proc/announce(var/annoucement)
+	for(var/obj/item/device/nuclear_challenge/vote/V in world)
+		V.audible_message("\icon[V] [annoucement]", null, 0)
+
+/proc/declare_nuclear_war(mob/living/user)
 	if(player_list.len < CHALLENGE_MIN_PLAYERS)
 		user << "The enemy crew is too small to be worth declaring war on."
 		return


### PR DESCRIPTION
### Intent of your Pull Request

Changes nuke ops declaring war to be a vote requiring 3/5 in favor.
#### Changelog

:cl:
tweak: All nuke ops start with an item that allows them to vote for war. War will be declared if 3 out of five nukeops vote yes.
/:cl:

So when your leader is afk for four and a half minutes and everyone decides to not do war, he doesn't come back and immediately press the war button.
