### PR TITLE
Mind Batterers

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -243,6 +243,7 @@ var/list/uplink_items = list()
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
+
 /*
 /datum/uplink_item/dangerous/tactical_dolphin
 	name = "Tactical Dolphin"
@@ -683,6 +684,13 @@ var/list/uplink_items = list()
 	cost = 16
 	gamemodes = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
 	surplus = 20
+
+/datum/uplink_item/device_tools/batterer
+	name = "Mind Batterer"
+	desc = "A powerful mental wave generator, which stuns all humanoids around the user. It has one use, but can be used in-hand to recharge it."
+	item = /obj/item/device/batterer
+	cost = 7
+	excludefrom = list(/datum/game_mode/nuclear,/datum/game_mode/gang)
 
 // IMPLANTS
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -17,7 +17,7 @@ effective or pretty fucking useless.
 
 /obj/item/device/batterer
 	name = "mind batterer"
-	desc = "A strange device with twin antennas."
+	desc = "A strange device with twin antennas. It has a small switch on the side."
 	icon_state = "batterer"
 	throwforce = 5
 	w_class = 1.0
@@ -28,13 +28,22 @@ effective or pretty fucking useless.
 	origin_tech = "magnets=3;combat=3;syndicate=3"
 
 	var/times_used = 0 //Number of times it's been used.
-	var/max_uses = 2
+	var/max_uses = 1
+	var/charging = 0
 
 
 /obj/item/device/batterer/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
+	if(charging == 1)
+		user <<"<span class='warning'>The mind batterer is charging!</span>"
+		return
 	if(!user) 	return
 	if(times_used >= max_uses)
-		user << "<span class='danger'>The mind batterer has been burnt out!</span>"
+		user << "<span class='danger'>The mind batterer is out of charges. You engage the charge mechanism.</span>"
+		charging = 1
+		spawn(100)
+			times_used--
+			charging = 0
+			icon_state = "batterer" // just in case the icon doesn't update correctly on the charge change
 		return
 
 	add_logs(user, null, "knocked down people in the area", src)

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -51,7 +51,7 @@ effective or pretty fucking useless.
 	for(var/mob/living/carbon/human/M in orange(5, user))
 		spawn()
 			if(prob(50))
-				M.Weaken(rand(5,15)
+				M.Weaken(rand(5,15))
 				M << "<span class='userdanger'>You feel a tremendous, paralyzing wave flood your mind.</span>"
 
 			else

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -51,7 +51,6 @@ effective or pretty fucking useless.
 	for(var/mob/living/carbon/human/M in orange(5, user))
 		spawn()
 			if(prob(50))
-
 				M.Weaken(rand(5,15)
 				M << "<span class='userdanger'>You feel a tremendous, paralyzing wave flood your mind.</span>"
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -48,13 +48,11 @@ effective or pretty fucking useless.
 
 	add_logs(user, null, "knocked down people in the area", src)
 
-	for(var/mob/living/carbon/human/M in orange(10, user))
+	for(var/mob/living/carbon/human/M in orange(5, user))
 		spawn()
 			if(prob(50))
 
-				M.Weaken(rand(10,20))
-				if(prob(25))
-					M.Stun(rand(5,10))
+				M.Weaken(rand(5,15)
 				M << "<span class='userdanger'>You feel a tremendous, paralyzing wave flood your mind.</span>"
 
 			else


### PR DESCRIPTION
Got this from @SeikoTheSeal
### Intent of your Pull Request

Adds mind batterers to the traitor uplink, for 7 TC. They have one use, but can be recharged manually by using it in-hand when it's out of charges. It takes 10 seconds to recharge.
#### Changelog

:cl: ShadowDeath6
rscadd: Adds Mind Batterers to traitor uplinks. It has a 50% chance per person to stun in an area around the user.
tweak: Mind batterers have one charge, but can be used in-hand when out of charge to recharge it. Recharge time takes 10 seconds.
/:cl:

I'm gonna be leaving for like 8 days so leave comments on how I can fix this or something.
