### PR TITLE
Adds the Exporter Device for Cargo Techs

### DIFF
--- a/code/game/jobs/job/cargo_service.dm
+++ b/code/game/jobs/job/cargo_service.dm
@@ -23,6 +23,7 @@ Quartermaster
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/brown(H), slot_shoes)
 	H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
 	H.equip_to_slot_or_del(new /obj/item/weapon/clipboard(H), slot_l_hand)
+	H.equip_to_slot_or_del(new /obj/item/device/export_scanner(H), slot_r_hand)
 
 /*
 Cargo Technician
@@ -47,6 +48,7 @@ Cargo Technician
 /datum/job/cargo_tech/equip_items(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/device/export_scanner(H), slot_l_hand)
 
 /*
 Shaft Miner

--- a/code/game/jobs/job/cargo_service.dm
+++ b/code/game/jobs/job/cargo_service.dm
@@ -47,6 +47,7 @@ Cargo Technician
 /datum/job/cargo_tech/equip_items(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
+	H.equip_to_slot_or_del(new /obj/item/device/export_scanner(H), slot_l_hand)
 
 /*
 Shaft Miner

--- a/code/game/jobs/job/cargo_service.dm
+++ b/code/game/jobs/job/cargo_service.dm
@@ -47,7 +47,6 @@ Cargo Technician
 /datum/job/cargo_tech/equip_items(mob/living/carbon/human/H)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/cargotech(H), slot_w_uniform)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sneakers/black(H), slot_shoes)
-	H.equip_to_slot_or_del(new /obj/item/device/export_scanner(H), slot_l_hand)
 
 /*
 Shaft Miner


### PR DESCRIPTION
Refer to issue #1285 .
### Intent of your Pull Request

Cargo Techs will now spawn in with their own exporter scanner, the export scanner values crates and items when linked to a cargo console.
#### Changelog

:cl:
rscadd: Adds exporter scanner to cargo techs.
/:cl:

Cargo Techs will now spawn in with their own exporter device.
