### PR TITLE
Nerfs the dual energy sword's block chance from 50% -> 0%

### DIFF
--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -51,7 +51,7 @@
 	throw_range = 5
 	flags = NOSHIELD
 	origin_tech = "magnets=3;syndicate=4"
-	block_chance = 50
+	block_chance = 0
 	var/hacked = 0
 
 /obj/item/weapon/melee/energy/sword/New()
@@ -60,7 +60,7 @@
 
 /obj/item/weapon/melee/energy/sword/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
 	if(active)
-		return ..()
+		return ..(owner, attack_text, final_block_chance)
 	return 0
 
 /obj/item/weapon/melee/energy/sword/attack(mob/vict, mob/usr)

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -203,7 +203,7 @@
 	origin_tech = "magnets=3;syndicate=4"
 	item_color = "green"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 10
+	block_chance = 0
 	var/hacked = 0
 
 /obj/item/weapon/twohanded/dualsaber/New()
@@ -238,7 +238,7 @@
 /obj/item/weapon/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(wielded)
 		if(attack_type == UNARMED_ATTACK)
-			return 1
+			final_block_chance += 70
 		return ..(owner, attack_text, final_block_chance)
 	return 0
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -235,8 +235,10 @@
 	else
 		user.adjustStaminaLoss(25)
 
-/obj/item/weapon/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
+/obj/item/weapon/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance, damage, attack_type)
 	if(wielded)
+		if(attack_type == UNARMED_ATTACK)
+			return 1
 		return ..(owner, attack_text, final_block_chance)
 	return 0
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -203,7 +203,7 @@
 	origin_tech = "magnets=3;syndicate=4"
 	item_color = "green"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	block_chance = 50
+	block_chance = 10
 	var/hacked = 0
 
 /obj/item/weapon/twohanded/dualsaber/New()
@@ -237,7 +237,7 @@
 
 /obj/item/weapon/twohanded/dualsaber/hit_reaction(mob/living/carbon/human/owner, attack_text, final_block_chance)
 	if(wielded)
-		return ..()
+		return ..(owner, attack_text, final_block_chance)
 	return 0
 
 /obj/item/weapon/twohanded/dualsaber/attack_hulk(mob/living/carbon/human/user)  //In case thats just so happens that it is still activated on the groud, prevents hulk from picking it up


### PR DESCRIPTION
### Intent of your Pull Request

Nerf the dual energy sword ... again.

Because once again there's no counters to it, and there should almost always be counters. Stunbatons should ALWAYS counter a traitor with a double energy sword, but as of now they don't.
#### Super3222

:cl:
tweak: Dual Eswords block chance is now 0. However, it'll still reflect energy projectiles. Not so much for ballistic or melee.
tweak: Eswords have a block chance has been lowered to 0.
/:cl:
